### PR TITLE
feat: Global Exception Handler 생성

### DIFF
--- a/src/main/java/com/lgcns/global/common/response/GlobalResponse.java
+++ b/src/main/java/com/lgcns/global/common/response/GlobalResponse.java
@@ -6,4 +6,8 @@ public record GlobalResponse<T>(boolean success, int status, T data, LocalDateTi
     public static <T> GlobalResponse<T> success(int status, T data) {
         return new GlobalResponse<>(true, status, data, LocalDateTime.now());
     }
+
+    public static <T> GlobalResponse<T> fail(int status, T errorResponse) {
+        return new GlobalResponse<>(false, status, errorResponse, LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/lgcns/global/error/ErrorResponse.java
+++ b/src/main/java/com/lgcns/global/error/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.global.error;
+
+public record ErrorResponse(String errorClassName, String message) {
+    public static ErrorResponse of(String errorClassName, String message) {
+        return new ErrorResponse(errorClassName, message);
+    }
+}

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(basePackages = "com.lgcns")
@@ -58,6 +59,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             HttpStatusCode status,
             WebRequest request) {
         final ErrorCode errorCode = GlobalErrorCode.METHOD_NOT_ALLOWED;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    /** PathVariable, RequestParam, RequestHeader, RequestBody 에서 타입이 일치하지 않을 경우 발생 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<GlobalResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        final ErrorCode errorCode = GlobalErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH;
         final ErrorResponse errorResponse =
                 ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
         final GlobalResponse response =

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -79,4 +79,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
     }
+
+    /** 500번대 에러 처리 */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<GlobalResponse> handleException(Exception e) {
+        final ErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
 }

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.lgcns.global.error;
+
+import com.lgcns.global.common.response.GlobalResponse;
+import com.lgcns.global.error.exception.CustomException;
+import com.lgcns.global.error.exception.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice(basePackages = "com.lgcns")
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<GlobalResponse> handleCustomException(CustomException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getErrorName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -3,9 +3,15 @@ package com.lgcns.global.error;
 import com.lgcns.global.common.response.GlobalResponse;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.error.exception.ErrorCode;
+import lombok.SneakyThrows;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(basePackages = "com.lgcns")
@@ -20,5 +26,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
 
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    /**
+     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다. HttpMessageConverter 에서 등록한
+     * HttpMessageConverter binding 못할경우 발생 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @SneakyThrows
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        final String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorMessage);
+        final GlobalResponse response =
+                GlobalResponse.fail(HttpStatus.BAD_REQUEST.value(), errorResponse);
+
+        return ResponseEntity.status(status).body(response);
     }
 }

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package com.lgcns.global.error;
 import com.lgcns.global.common.response.GlobalResponse;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.error.exception.ErrorCode;
+import com.lgcns.global.error.exception.GlobalErrorCode;
 import lombok.SneakyThrows;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -46,5 +48,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 GlobalResponse.fail(HttpStatus.BAD_REQUEST.value(), errorResponse);
 
         return ResponseEntity.status(status).body(response);
+    }
+
+    /** 지원하지 않은 HTTP method 호출 할 경우 발생 */
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        final ErrorCode errorCode = GlobalErrorCode.METHOD_NOT_ALLOWED;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
     }
 }

--- a/src/main/java/com/lgcns/global/error/exception/CustomException.java
+++ b/src/main/java/com/lgcns/global/error/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.lgcns.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/lgcns/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.lgcns.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+
+    String getErrorName();
+}

--- a/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 값의 타입이 잘못되어 처리할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorCode implements ErrorCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
     METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 값의 타입이 잘못되어 처리할 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
@@ -1,0 +1,20 @@
+package com.lgcns.global.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getErrorName() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-45]

---
## 📌 작업 내용 및 특이사항

- 전역 예외 처리용 GlobalExceptionHandler을 생성하였습니다.
- 스프링 예외를 미리 처리해둔 ResponseEntityExceptionHandler를 상속받아 사용합니다.
- 기본적인 예외, Custom 예외, 500번대 예외만 잡아두었습니다.
- ErrorCode를 인터페이스로 구현하였으니 각 도메인 패키지에서 오버라이딩해서 에러코드를 구현해주시면 됩니다.

---
## 📚 참고사항

- https://github.com/cheese10yun/spring-guide/blob/master/docs/exception-guide.md#%ED%86%B5%EC%9D%BC%EB%90%9C-error-response-%EA%B0%9D%EC%B2%B4

[LCR-45]: https://lgcns-retail.atlassian.net/browse/LCR-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ