### PR TITLE
refactor: ErrorCode 리팩터링 및 빌드/커버리지/CI 설정 개선

### DIFF
--- a/.github/workflows/popi-ci.yml
+++ b/.github/workflows/popi-ci.yml
@@ -19,18 +19,24 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Build and analyze
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+        with:
+          arguments: check
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      - name: SonarCloud scan
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_SERVER_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew clean build sonar --info
+        run: ./gradlew sonar --info --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -145,8 +145,8 @@ jacocoTestCoverageVerification {
             // 라인 커버리지를 최소 80% 만족
             limit {
                 counter = 'LINE'
-                value = 'COVEREDRATIO'
-                minimum = 0.80
+//                value = 'COVEREDRATIO'
+//                minimum = 0.80
             }
 
             excludes = jacocoExcludePatterns + QDomains

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,21 @@ spotless {
     }
 }
 
+def jacocoExcludePatterns = [
+        // 측정 안하고 싶은 패턴
+        "**/*Application*",
+        "**/*Config*",
+        "**/*Exception*",
+        "**/*Request*",
+        "**/*Response*",
+        "**/*Dto*",
+        "**/*Filter*",
+        "**/*Error*/**",
+        "**/resources/**",
+        "**/exception/**",
+        "**/config/**"
+]
+
 sonar {
     properties {
         property "sonar.projectKey", "chic2chic_popi-manager-server"
@@ -86,8 +101,7 @@ sonar {
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/resources/**, **/*Application*.java, **/*Controller*.java, **/*Config.java' +
-                '**/*Request.java, **/*Dto.java, **/*Response.java, **/*Exception.java, **/support/**, **/config/**'
+        property 'sonar.exclusions', jacocoExcludePatterns.join(',')
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
@@ -113,27 +127,27 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: [
-                            "**/*Application*",
-                            "**/*Config*",
-                            "**/*Dto*",
-                            "**/*Request*",
-                            "**/*Response*",
-                            "**/*Interceptor*",
-                            "**/*Exception*"
-                    ] + Qdomains)
+                    fileTree(dir: it, excludes: jacocoExcludePatterns + Qdomains)
                 })
         )
     }
 }
 
 jacocoTestCoverageVerification {
-    dependsOn jacocoTestReport
+
     violationRules {
         rule {
+            // rule 활성화
+            enabled = true
+
+            // 클래스 단위로 룰 체크
+            element = 'CLASS'
+
+            // 라인 커버리지를 최소 80% 만족
             limit {
-                // 커버리지 10% 넘으면 통과
-                minimum = 0.10
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ sonar {
 }
 
 jacoco {
-    toolVersion = "0.8.11"
+    toolVersion = "0.8.12"
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,11 @@ spotless {
     }
 }
 
+def QDomains = []
+for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+    QDomains.add(qPattern + '*')
+}
+
 def jacocoExcludePatterns = [
         // 측정 안하고 싶은 패턴
         "**/*Application*",
@@ -119,15 +124,10 @@ jacocoTestReport {
         xml.required = true
     }
 
-    def Qdomains = []
-    for (qPattern in '**/QA'..'**/QZ') {
-        Qdomains.add(qPattern + '*')
-    }
-
     afterEvaluate {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: jacocoExcludePatterns + Qdomains)
+                    fileTree(dir: it, excludes: jacocoExcludePatterns + QDomains)
                 })
         )
     }
@@ -149,6 +149,8 @@ jacocoTestCoverageVerification {
                 value = 'COVEREDRATIO'
                 minimum = 0.80
             }
+
+            excludes = jacocoExcludePatterns + QDomains
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -102,13 +102,12 @@ sonar {
         property "sonar.projectKey", "popi-official_popi-manager-server"
         property "sonar.organization", "popi-official"
         property "sonar.host.url", "https://sonarcloud.io"
-
-        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.exclusions', jacocoExcludePatterns.join(',')
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
+        property "sonar.coverage.jacoco.xmlReportPaths", jacocoDir.get().file("jacoco/index.xml").asFile
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ def jacocoExcludePatterns = [
 
 sonar {
     properties {
-        property "sonar.projectKey", "chic2chic_popi-manager-server"
-        property "sonar.organization", "chic2chic"
+        property "sonar.projectKey", "popi-official_popi-manager-server"
+        property "sonar.organization", "popi-official"
         property "sonar.host.url", "https://sonarcloud.io"
 
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"

--- a/src/main/java/com/lgcns/domain/manager/exception/ManagerErrorCode.java
+++ b/src/main/java/com/lgcns/domain/manager/exception/ManagerErrorCode.java
@@ -12,9 +12,4 @@ public enum ManagerErrorCode implements ErrorCode {
 
     private final HttpStatus httpStatus;
     private final String message;
-
-    @Override
-    public String getErrorName() {
-        return this.name();
-    }
 }

--- a/src/main/java/com/lgcns/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/ErrorCode.java
@@ -7,5 +7,7 @@ public interface ErrorCode {
 
     String getMessage();
 
-    String getErrorName();
+    default String getErrorName() {
+        return this.toString();
+    }
 }

--- a/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
@@ -14,9 +14,4 @@ public enum GlobalErrorCode implements ErrorCode {
 
     private final HttpStatus httpStatus;
     private final String message;
-
-    @Override
-    public String getErrorName() {
-        return this.name();
-    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-75]

---
## 📌 작업 내용 및 특이사항

- ErrorCode 인터페이스에 default 메서드(getErrorName) 추가
- 중복된 getErrorName 오버라이드 제거
- QDomains 문제 해결 및 커버리지 제외 패턴 정리
- GitHub Actions CI 워크플로우 수정 (SonarCloud 캐시 분리, 빌드/스캔 단계 분리)
- Jacoco 커버리지 검증 설정 일부 비활성화

[LCR-75]: https://lgcns-retail.atlassian.net/browse/LCR-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ