### PR TITLE
feat: 이미지 업로드를 위한 S3 Presigned URL 발급 구현

### DIFF
--- a/.github/workflows/popi-ci.yml
+++ b/.github/workflows/popi-ci.yml
@@ -33,4 +33,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_SERVER_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
         run: ./gradlew clean build sonar --info

--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,10 @@ dependencies {
 
     // AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.782'
-    implementation 'software.amazon.awssdk:s3:2.31.30'
-    implementation 'software.amazon.awssdk:s3control:2.31.30'
-    implementation 'software.amazon.awssdk:s3outposts:2.31:30'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.767'
+    implementation 'software.amazon.awssdk:s3:2.27.3'
+    implementation 'software.amazon.awssdk:s3control:2.27.3'
+    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,13 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.782'
+    implementation 'software.amazon.awssdk:s3:2.31.30'
+    implementation 'software.amazon.awssdk:s3control:2.31.30'
+    implementation 'software.amazon.awssdk:s3outposts:2.31:30'
 }
 
 spotless {

--- a/src/main/java/com/lgcns/infra/s3/S3Config.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Config.java
@@ -1,0 +1,33 @@
+package com.lgcns.infra.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client)
+                AmazonS3ClientBuilder.standard()
+                        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                        .withRegion(region)
+                        .build();
+    }
+}

--- a/src/main/java/com/lgcns/infra/s3/S3Controller.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Controller.java
@@ -1,0 +1,29 @@
+package com.lgcns.infra.s3;
+
+import com.lgcns.infra.s3.dto.request.FileNameRequest;
+import com.lgcns.infra.s3.dto.response.PreSignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "7. S3 API", description = "AWS S3 관련 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/S3")
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/presigned-url")
+    @Operation(
+            summary = "S3 preSigned url 생성",
+            description = "파일 이름을 입력 받아 S3 preSigned URL을 생성합니다.")
+    public PreSignedUrlResponse preSignedUrlCreate(@RequestBody @Valid FileNameRequest request) {
+        return s3Service.createPreSignedUrl("popi", request.fileName());
+    }
+}

--- a/src/main/java/com/lgcns/infra/s3/S3Controller.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Controller.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "7. S3 API", description = "AWS S3 관련 API 입니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/S3")
+@RequestMapping("/s3")
 public class S3Controller {
 
     private final S3Service s3Service;
@@ -22,7 +22,7 @@ public class S3Controller {
     @PostMapping("/presigned-url")
     @Operation(
             summary = "S3 preSigned url 생성",
-            description = "파일 이름을 입력 받아 S3 preSigned URL을 생성합니다.")
+            description = "파일 이름을 입력받아 S3 preSigned URL을 생성합니다.<br>" + "파일 이름에 파일 확장자는 필수입니다.")
     public PreSignedUrlResponse preSignedUrlCreate(@RequestBody @Valid FileNameRequest request) {
         return s3Service.createPreSignedUrl("popi", request.fileName());
     }

--- a/src/main/java/com/lgcns/infra/s3/S3Service.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Service.java
@@ -1,0 +1,94 @@
+package com.lgcns.infra.s3;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.lgcns.infra.s3.dto.response.PreSignedUrlResponse;
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    /**
+     * presigned url 발급
+     *
+     * @param prefix 버킷 디렉토리 이름
+     * @param fileName 클라이언트가 전달한 파일명 파라미터
+     * @return presigned url
+     */
+    public PreSignedUrlResponse createPreSignedUrl(String prefix, String fileName) {
+        if (!prefix.isEmpty()) {
+            fileName = createPath(prefix, fileName);
+        }
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                getGeneratePreSignedUrlRequest(bucket, fileName);
+        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return PreSignedUrlResponse.from(url.toString());
+    }
+
+    /**
+     * 파일 업로드용(PUT) presigned url 생성
+     *
+     * @param bucket 버킷 이름
+     * @param fileName S3 업로드용 파일 이름
+     * @return presigned url
+     */
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(
+            String bucket, String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileName)
+                        .withMethod(HttpMethod.PUT)
+                        .withExpiration(getPreSignedUrlExpiration());
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+        return generatePresignedUrlRequest;
+    }
+
+    /**
+     * presigned url 유효 기간 설정(2분)
+     *
+     * @return 유효기간
+     */
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 2;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    /**
+     * 파일 고유 ID를 생성
+     *
+     * @return 36자리의 UUID
+     */
+    private String createFileId() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * 파일의 전체 경로를 생성
+     *
+     * @param prefix 디렉토리 경로
+     * @return 파일의 전체 경로
+     */
+    private String createPath(String prefix, String fileName) {
+        String fileId = createFileId();
+        return String.format("%s/%s", prefix, fileId + fileName);
+    }
+}

--- a/src/main/java/com/lgcns/infra/s3/dto/request/FileNameRequest.java
+++ b/src/main/java/com/lgcns/infra/s3/dto/request/FileNameRequest.java
@@ -1,0 +1,9 @@
+package com.lgcns.infra.s3.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "S3 업로드 파일 이름 DTO")
+public record FileNameRequest(
+        @NotBlank(message = "파일 이름은 필수입니다.") @Schema(description = "파일 이름", example = "popi")
+                String fileName) {}

--- a/src/main/java/com/lgcns/infra/s3/dto/request/FileNameRequest.java
+++ b/src/main/java/com/lgcns/infra/s3/dto/request/FileNameRequest.java
@@ -5,5 +5,5 @@ import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "S3 업로드 파일 이름 DTO")
 public record FileNameRequest(
-        @NotBlank(message = "파일 이름은 필수입니다.") @Schema(description = "파일 이름", example = "popi")
+        @NotBlank(message = "파일 이름은 필수입니다.") @Schema(description = "파일 이름", example = "popi.jpg")
                 String fileName) {}

--- a/src/main/java/com/lgcns/infra/s3/dto/response/PreSignedUrlResponse.java
+++ b/src/main/java/com/lgcns/infra/s3/dto/response/PreSignedUrlResponse.java
@@ -1,0 +1,14 @@
+package com.lgcns.infra.s3.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "S3 PreSigned URL DTO")
+public record PreSignedUrlResponse(
+        @Schema(
+                        description = "preSigned URL",
+                        example = "https://popitestbucket.s3.ap-northeast-2.amazonaws.com/popi/abc")
+                String preSignedUrl) {
+    public static PreSignedUrlResponse from(String preSignedUrl) {
+        return new PreSignedUrlResponse(preSignedUrl);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,13 @@ spring-doc:
     disable-swagger-default-url: true
     path: /swagger-ui
     doc-expansion: none
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET:popitestbucket}
+    stack.auto: false
+    region.static: ${S3_REGION:ap-northeast-2}
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_SECRET_KEY}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-63]

---
## 📌 작업 내용 및 특이사항

- 일단 제 계정으로 S3 버킷 생성하고, Presigned URL 발급 기능을 구현했습니다.
- S3 엑세스 키, 시크릿 키는 환경변수로 설정하고 워크플로우에 추가했습니다.

---
## 📚 참고사항

1. 백엔드에 Presigned URL 발급 요청
2. 프론트엔드가 발급된 URL에 이미지 포함해서 PUT 요청
3. 백엔드는 URL을 DB에 저장


[LCR-63]: https://lgcns-retail.atlassian.net/browse/LCR-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ