### PR TITLE
feat: 쿠키 기반 리프레시 토큰 처리 및 JWT 재발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ def jacocoExcludePatterns = [
         "**/resources/**",
         "**/exception/**",
         "**/config/**",
+        "**/*Auth*",
         "**/*Jwt*",
         "**/*Token*",
         "**/*Util*",

--- a/src/main/java/com/lgcns/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/lgcns/domain/auth/controller/AuthController.java
@@ -1,7 +1,17 @@
 package com.lgcns.domain.auth.controller;
 
+import static com.lgcns.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import com.lgcns.domain.auth.dto.response.TokenReissueResponse;
+import com.lgcns.domain.auth.service.AuthService;
+import com.lgcns.global.util.CookieUtil;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +19,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 @Tag(name = "1-1. 인증 API", description = "인증 관련 API입니다.")
-public class AuthController {}
+public class AuthController {
+
+    private final AuthService authService;
+    private final CookieUtil cookieUtil;
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "만료된 엑세스 토큰이 있을 경우, 리프레시 토큰을 이용해 엑세스 및 리프레시 토큰을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenReissueResponse> tokenReissue(
+            @CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshTokenValue) {
+        TokenReissueResponse response = authService.reissueToken(refreshTokenValue);
+
+        String refreshToken = response.refreshToken();
+        HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);
+
+        return ResponseEntity.ok().headers(headers).body(response);
+    }
+}

--- a/src/main/java/com/lgcns/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/lgcns/domain/auth/domain/RefreshToken.java
@@ -21,4 +21,9 @@ public class RefreshToken {
         this.token = token;
         this.ttl = ttl;
     }
+
+    public void updateRefreshToken(String token, long ttl) {
+        this.token = token;
+        this.ttl = ttl;
+    }
 }

--- a/src/main/java/com/lgcns/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/com/lgcns/domain/auth/dto/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package com.lgcns.domain.auth.dto;
+
+import com.lgcns.domain.manager.domain.ManagerRole;
+
+public record AccessTokenDto(Long managerId, ManagerRole role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, ManagerRole role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/src/main/java/com/lgcns/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/lgcns/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.auth.dto;
+
+public record RefreshTokenDto(Long managerId, String refreshTokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long managerId, String refreshTokenValue, Long ttl) {
+        return new RefreshTokenDto(managerId, refreshTokenValue, ttl);
+    }
+}

--- a/src/main/java/com/lgcns/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/lgcns/domain/auth/dto/response/LoginResponse.java
@@ -1,11 +1,11 @@
 package com.lgcns.domain.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LoginResponse(
         @Schema(description = "액세스 토큰") String accessToken,
-        @Schema(description = "리프레시 토큰") String refreshToken) {
-
+        @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken) {
     public static LoginResponse of(String accessToken, String refreshToken) {
         return new LoginResponse(accessToken, refreshToken);
     }

--- a/src/main/java/com/lgcns/domain/auth/dto/response/TokenReissueResponse.java
+++ b/src/main/java/com/lgcns/domain/auth/dto/response/TokenReissueResponse.java
@@ -1,0 +1,12 @@
+package com.lgcns.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenReissueResponse(
+        @Schema(description = "엑세스 토큰") String accessToken,
+        @JsonIgnore @Schema(description = "리프레시 토큰") String refreshToken) {
+    public static TokenReissueResponse of(String accessToken, String refreshToken) {
+        return new TokenReissueResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/lgcns/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/lgcns/domain/auth/exception/AuthErrorCode.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다.");
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "유효한 리프레시 토큰이 존재하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다. 다시 로그인해주세요."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/lgcns/domain/auth/service/AuthService.java
+++ b/src/main/java/com/lgcns/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.auth.service;
+
+import com.lgcns.domain.auth.dto.response.TokenReissueResponse;
+
+public interface AuthService {
+    TokenReissueResponse reissueToken(String refreshTokenValue);
+}

--- a/src/main/java/com/lgcns/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,46 @@
+package com.lgcns.domain.auth.service;
+
+import com.lgcns.domain.auth.dto.AccessTokenDto;
+import com.lgcns.domain.auth.dto.RefreshTokenDto;
+import com.lgcns.domain.auth.dto.response.TokenReissueResponse;
+import com.lgcns.domain.auth.exception.AuthErrorCode;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.manager.exception.ManagerErrorCode;
+import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private final JwtTokenService jwtTokenService;
+    private final ManagerRepository managerRepository;
+
+    @Override
+    public TokenReissueResponse reissueToken(String refreshTokenValue) {
+        RefreshTokenDto oldRefreshTokenDto =
+                jwtTokenService.validateRefreshToken(refreshTokenValue);
+
+        if (oldRefreshTokenDto == null) {
+            throw new CustomException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        RefreshTokenDto newRefreshTokenDto =
+                jwtTokenService.reissueRefreshToken(oldRefreshTokenDto);
+        AccessTokenDto newAccessTokenDto =
+                jwtTokenService.reissueAccessToken(getManager(newRefreshTokenDto));
+
+        return TokenReissueResponse.of(
+                newAccessTokenDto.accessTokenValue(), newRefreshTokenDto.refreshTokenValue());
+    }
+
+    private Manager getManager(RefreshTokenDto refreshTokenDto) {
+        return managerRepository
+                .findById(refreshTokenDto.managerId())
+                .orElseThrow(() -> new CustomException(ManagerErrorCode.MANAGER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/lgcns/domain/auth/service/JwtTokenService.java
+++ b/src/main/java/com/lgcns/domain/auth/service/JwtTokenService.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.auth.service;
 
 import com.lgcns.domain.auth.domain.RefreshToken;
+import com.lgcns.domain.auth.dto.AccessTokenDto;
 import com.lgcns.domain.auth.repository.RefreshTokenRepository;
 import com.lgcns.domain.manager.domain.ManagerRole;
 import com.lgcns.global.util.JwtUtil;
@@ -30,5 +31,13 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/lgcns/domain/auth/service/JwtTokenService.java
+++ b/src/main/java/com/lgcns/domain/auth/service/JwtTokenService.java
@@ -2,8 +2,12 @@ package com.lgcns.domain.auth.service;
 
 import com.lgcns.domain.auth.domain.RefreshToken;
 import com.lgcns.domain.auth.dto.AccessTokenDto;
+import com.lgcns.domain.auth.dto.RefreshTokenDto;
+import com.lgcns.domain.auth.exception.AuthErrorCode;
 import com.lgcns.domain.auth.repository.RefreshTokenRepository;
+import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.domain.ManagerRole;
+import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,5 +43,29 @@ public class JwtTokenService {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public RefreshTokenDto reissueRefreshToken(RefreshTokenDto oldRefreshTokenDto) {
+        RefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(oldRefreshTokenDto.managerId())
+                        .orElseThrow(
+                                () -> new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        RefreshTokenDto refreshTokenDto =
+                jwtUtil.generateRefreshTokenDto(refreshToken.getManagerId());
+        refreshToken.updateRefreshToken(refreshTokenDto.refreshTokenValue(), refreshTokenDto.ttl());
+
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenDto;
+    }
+
+    public AccessTokenDto reissueAccessToken(Manager manager) {
+        return jwtUtil.generateAccessTokenDto(manager.getId(), manager.getRole());
+    }
+
+    public RefreshTokenDto validateRefreshToken(String refreshToken) {
+        return jwtUtil.parseRefreshToken(refreshToken);
     }
 }

--- a/src/main/java/com/lgcns/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/lgcns/global/common/constants/SecurityConstants.java
@@ -1,0 +1,5 @@
+package com.lgcns.global.common.constants;
+
+public final class SecurityConstants {
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+}

--- a/src/main/java/com/lgcns/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/lgcns/global/common/constants/SecurityConstants.java
@@ -1,5 +1,7 @@
 package com.lgcns.global.common.constants;
 
 public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "role";
+
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 }

--- a/src/main/java/com/lgcns/global/common/constants/SecurityConstants.java
+++ b/src/main/java/com/lgcns/global/common/constants/SecurityConstants.java
@@ -2,6 +2,7 @@ package com.lgcns.global.common.constants;
 
 public final class SecurityConstants {
     public static final String TOKEN_ROLE_NAME = "role";
+    public static final String TOKEN_PREFIX = "Bearer ";
 
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 }

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -53,7 +53,7 @@ public class WebSecurityConfig {
 
         http.authorizeHttpRequests(
                 auth ->
-                        auth.requestMatchers("/managers", "/auth/login")
+                        auth.requestMatchers("/managers", "/auth/**")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -3,10 +3,8 @@ package com.lgcns.global.config.security;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.security.config.Customizer.withDefaults;
 
-import com.lgcns.global.security.AuthenticationFilter;
-import com.lgcns.global.security.CustomUserDetailsService;
-import com.lgcns.global.security.LoginFailureHandler;
-import com.lgcns.global.security.LoginSuccessHandler;
+import com.lgcns.domain.auth.service.JwtTokenService;
+import com.lgcns.global.security.*;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -38,6 +36,7 @@ public class WebSecurityConfig {
     private final CustomUserDetailsService customUserDetailsService;
     private final LoginSuccessHandler loginSuccessHandler;
     private final LoginFailureHandler loginFailureHandler;
+    private final JwtTokenService jwtTokenService;
 
     private void defaultFilterChain(HttpSecurity http) throws Exception {
         http.httpBasic(AbstractHttpConfigurer::disable)
@@ -58,6 +57,10 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());
+
+        http.addFilterBefore(
+                jwtAuthenticationFilter(jwtTokenService),
+                UsernamePasswordAuthenticationFilter.class);
 
         http.addFilterAt(authenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
@@ -113,5 +116,10 @@ public class WebSecurityConfig {
         loginFilter.setAuthenticationSuccessHandler(loginSuccessHandler);
         loginFilter.setAuthenticationFailureHandler(loginFailureHandler);
         return loginFilter;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenService jwtTokenService) {
+        return new JwtAuthenticationFilter(jwtTokenService);
     }
 }

--- a/src/main/java/com/lgcns/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lgcns/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.lgcns.global.security;
+
+import static com.lgcns.global.common.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.lgcns.domain.auth.dto.AccessTokenDto;
+import com.lgcns.domain.auth.service.JwtTokenService;
+import com.lgcns.domain.manager.domain.ManagerRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+
+            // AT가 유효하면 통과
+            if (accessTokenDto != null) {
+                setAuthenticationToken(accessTokenDto.managerId(), accessTokenDto.role());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToken(Long managerId, ManagerRole managerRole) {
+        UserDetails userDetails =
+                User.withUsername(managerId.toString())
+                        .password("")
+                        .authorities(managerRole.toString())
+                        .build();
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.replace(TOKEN_PREFIX, "");
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/lgcns/global/security/LoginSuccessHandler.java
+++ b/src/main/java/com/lgcns/global/security/LoginSuccessHandler.java
@@ -5,10 +5,12 @@ import com.lgcns.domain.auth.dto.response.LoginResponse;
 import com.lgcns.domain.auth.service.JwtTokenService;
 import com.lgcns.domain.manager.domain.ManagerRole;
 import com.lgcns.global.common.response.GlobalResponse;
+import com.lgcns.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -19,6 +21,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
     private static final String RESPONSE_CONTENT_TYPE = "application/json;charset=utf-8";
     private final ObjectMapper objectMapper;
     private final JwtTokenService jwtTokenService;
+    private final CookieUtil cookieUtil;
 
     @Override
     public void onAuthenticationSuccess(
@@ -35,6 +38,9 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         String accessToken = jwtTokenService.createAccessToken(managerId, managerRole);
         String refreshToken = jwtTokenService.createRefreshToken(managerId);
+
+        HttpHeaders httpHeaders = cookieUtil.generateRefreshTokenCookie(refreshToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, httpHeaders.getFirst(HttpHeaders.SET_COOKIE));
 
         LoginResponse loginResponse = LoginResponse.of(accessToken, refreshToken);
 

--- a/src/main/java/com/lgcns/global/util/CookieUtil.java
+++ b/src/main/java/com/lgcns/global/util/CookieUtil.java
@@ -1,0 +1,27 @@
+package com.lgcns.global.util;
+
+import static com.lgcns.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(Cookie.SameSite.NONE.attributeValue())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+}

--- a/src/main/java/com/lgcns/global/util/JwtUtil.java
+++ b/src/main/java/com/lgcns/global/util/JwtUtil.java
@@ -105,7 +105,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .setIssuer(jwtProperties.issuer())
                 .setSubject(managerId.toString())
-                .claim("authorities", role.getRole())
+                .claim(TOKEN_ROLE_NAME, role.name())
                 .setIssuedAt(issuedAt)
                 .setExpiration(expiredAt)
                 .signWith(getAccessTokenKey())

--- a/src/main/java/com/lgcns/global/util/JwtUtil.java
+++ b/src/main/java/com/lgcns/global/util/JwtUtil.java
@@ -25,8 +25,8 @@ public class JwtUtil {
         Date issuedAt = new Date();
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
-        String tokenValue = buildAccessToken(managerId, managerRole, issuedAt, expiredAt);
-        return new AccessTokenDto(managerId, managerRole, tokenValue);
+        String accessTokenValue = buildAccessToken(managerId, managerRole, issuedAt, expiredAt);
+        return new AccessTokenDto(managerId, managerRole, accessTokenValue);
     }
 
     public String generateAccessToken(Long managerId, ManagerRole role) {

--- a/src/main/java/com/lgcns/global/util/JwtUtil.java
+++ b/src/main/java/com/lgcns/global/util/JwtUtil.java
@@ -1,7 +1,14 @@
 package com.lgcns.global.util;
 
+import static com.lgcns.global.common.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+import com.lgcns.domain.auth.dto.AccessTokenDto;
+import com.lgcns.domain.auth.dto.RefreshTokenDto;
 import com.lgcns.domain.manager.domain.ManagerRole;
 import com.lgcns.infra.jwt.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
@@ -26,6 +33,42 @@ public class JwtUtil {
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
         return buildRefreshToken(managerId, issuedAt, expiredAt);
+    }
+
+    public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(accessTokenValue, getAccessTokenKey());
+
+            return AccessTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    ManagerRole.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
+                    accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());
+
+            return RefreshTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    refreshTokenValue,
+                    jwtProperties.refreshTokenExpirationTime());
+        } catch (ExpiredJwtException e) {
+            return null;
+        }
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 
     public long getRefreshTokenExpirationTime() {

--- a/src/main/java/com/lgcns/global/util/JwtUtil.java
+++ b/src/main/java/com/lgcns/global/util/JwtUtil.java
@@ -21,11 +21,28 @@ import org.springframework.stereotype.Component;
 public class JwtUtil {
     private final JwtProperties jwtProperties;
 
+    public AccessTokenDto generateAccessTokenDto(Long managerId, ManagerRole managerRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String tokenValue = buildAccessToken(managerId, managerRole, issuedAt, expiredAt);
+        return new AccessTokenDto(managerId, managerRole, tokenValue);
+    }
+
     public String generateAccessToken(Long managerId, ManagerRole role) {
         Date issuedAt = new Date();
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
         return buildAccessToken(managerId, role, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String refreshTokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return RefreshTokenDto.of(
+                memberId, refreshTokenValue, jwtProperties.refreshTokenExpirationTime());
     }
 
     public String generateRefreshToken(Long managerId) {


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-90]

---
## 📌 작업 내용 및 특이사항

- 액세스 토큰 만료 시, 리프레시 토큰을 이용해 새로운 토큰을 재발급하는 API를 추가하였습니다.
- 토큰 재발급 API에서는 @CookieValue를 통해 브라우저에 저장된 리프레시 토큰 쿠키를 추출하고, 이를 검증하여 토큰을 재발급합니다.
- 재발급된 리프레시 토큰은 HttpOnly 쿠키로 반환되며, 엑세스 토큰은 응답 바디에 포함됩니다.
- JWT 인증 필터(JwtAuthenticationFilter)를 추가하여, 액세스 토큰이 유효한 경우 사용자 인증 정보를 SecurityContext에 설정하도록 처리하였습니다.


---
## 📚 참고사항

- 토큰 재발급 테스트의 경우 유저 서버의 PR과 내용이 거의 유사하니 참고하시기 바랍니다~


[LCR-90]: https://lgcns-retail.atlassian.net/browse/LCR-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ