### PR TITLE
feat: 현재 로그인한 매니저 조회 유틸리티 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/lgcns/domain/auth/exception/AuthErrorCode.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "유효한 리프레시 토큰이 존재하지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다. 다시 로그인해주세요."),
+
+    AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 인증 정보를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lgcns/global/util/ManagerUtil.java
+++ b/src/main/java/com/lgcns/global/util/ManagerUtil.java
@@ -1,0 +1,34 @@
+package com.lgcns.global.util;
+
+import com.lgcns.domain.auth.exception.AuthErrorCode;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.manager.exception.ManagerErrorCode;
+import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ManagerUtil {
+
+    private final ManagerRepository managerRepository;
+
+    public Manager getCurrentManager() {
+        return managerRepository
+                .findById(getCurrentManagerId())
+                .orElseThrow(() -> new CustomException(ManagerErrorCode.MANAGER_NOT_FOUND));
+    }
+
+    public Long getCurrentManagerId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (Exception e) {
+            throw new CustomException(AuthErrorCode.AUTH_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/lgcns/global/util/ManagerUtilTest.java
+++ b/src/test/java/com/lgcns/global/util/ManagerUtilTest.java
@@ -1,0 +1,42 @@
+package com.lgcns.global.util;
+
+import com.lgcns.IntegrationTest;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.global.security.PrincipalDetails;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class ManagerUtilTest extends IntegrationTest {
+
+    @Autowired private ManagerUtil managerUtil;
+    @Autowired private ManagerRepository managerRepository;
+
+    private Manager manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = managerRepository.save(Manager.createManager("testUsername", "testPassword"));
+
+        UserDetails userDetails = new PrincipalDetails(manager.getId(), manager.getRole(), null);
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Test
+    void 로그인한_매니저의_정보를_조회한다() {
+        // when
+        Manager currentManager = managerUtil.getCurrentManager();
+
+        // then
+        Assertions.assertEquals(manager.getId(), currentManager.getId());
+        Assertions.assertEquals(manager.getRole(), currentManager.getRole());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-91]

---
## 📌 작업 내용 및 특이사항

- 현재 로그인한 매니저 정보를 조회하는 유틸 클래스를 추가했습니다.
- SecurityContext에서 ID를 읽어 DB에서 매니저를 조회하며, 인증 정보가 없을 경우 예외를 던집니다.
- 서비스 레이어에서 주입받아 사용하시면 됩니다.

---
## 📚 참고사항

- 추후 서비스 레이어 테스트에서 인증이 필요한 경우 아래와 같이 ```@BeforeEach```를 활용해 SecurityContext에 인증 정보를 미리 주입하시기 바랍니다.

```java
@Autowired private ManagerRepository managerRepository;

private Manager manager;

@BeforeEach
void setUp() {
    manager = managerRepository.save(Manager.createManager("testUsername", "testPassword"));

    UserDetails userDetails = new PrincipalDetails(manager.getId(), manager.getRole(), null);
    UsernamePasswordAuthenticationToken token =
            new UsernamePasswordAuthenticationToken(
                    userDetails, null, userDetails.getAuthorities());
    SecurityContextHolder.getContext().setAuthentication(token);
}
```

[LCR-91]: https://lgcns-retail.atlassian.net/browse/LCR-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ