### PR TITLE
chore: Spring Boot Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,15 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -53,7 +53,11 @@ public class WebSecurityConfig {
 
         http.authorizeHttpRequests(
                 auth ->
-                        auth.requestMatchers("/managers", "/auth/**")
+                        auth.requestMatchers("/manager-actuator/**")
+                                .permitAll()
+                                .requestMatchers("/managers")
+                                .permitAll()
+                                .requestMatchers("/auth/login")
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated());

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: "actuator"
+management:
+  endpoints:
+    jmx:
+      exposure:
+        exclude: "*"
+    web:
+      exposure:
+        include: health
+      base-path: /manager-actuator
+    access:
+      default: none
+  endpoint:
+    health:
+      access: unrestricted

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     group:
       test: "test"
       local: "local, datasource"
-      dev: "dev, datasource"
+      dev: "dev, datasource, actuator"
     include:
       - redis
       - security


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-100]

---
## 📌 작업 내용 및 특이사항

- /manager-actuator/health로 헬스 체크를 할 수 있습니다.
- actuator 보안 설정을 추가하였습니다.
  - 기본적으로 모든 엔드포인트를 비활성화했습니다. (enabled-by-default는 deprecated로 인해 access-default)
  - health 엔드포인트만 활성화했습니다.
  - JMX 엔드포인트는 모두 비활성화하고, health 엔드포인트만 노출하도록 설정했습니다.
  - actuator 기본 경로를 /manager-actuator/health로 변경하였습니다.

---
## 📚 참고사항

-


[LCR-100]: https://lgcns-retail.atlassian.net/browse/LCR-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ