### PR TITLE
refactor: 팝업 등록 반환값 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/controller/PopupController.java
+++ b/src/main/java/com/lgcns/domain/popup/controller/PopupController.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.popup.controller;
 
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
+import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.service.PopupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,9 +21,9 @@ public class PopupController {
 
     @PostMapping
     @Operation(summary = "팝업 등록", description = "팝업과 설문지, 보기 문항을 모두 작성한 후 등록합니다.")
-    public ResponseEntity<Void> popupCreate(
+    public ResponseEntity<PopupCreateResponse> popupCreate(
             @RequestBody @Valid PopupWithChoicesCreateRequest popupWithChoicesCreateRequest) {
-        popupService.createPopup(popupWithChoicesCreateRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        PopupCreateResponse response = popupService.createPopup(popupWithChoicesCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/lgcns/domain/popup/dto/response/PopupCreateResponse.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/PopupCreateResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.popup.dto.response;
+
+public record PopupCreateResponse(Long popupId) {
+    public static PopupCreateResponse of(Long popupId) {
+        return new PopupCreateResponse(popupId);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -1,8 +1,9 @@
 package com.lgcns.domain.popup.service;
 
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
+import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 
 public interface PopupService {
 
-    void createPopup(PopupWithChoicesCreateRequest popupWithChoicesCreateRequest);
+    PopupCreateResponse createPopup(PopupWithChoicesCreateRequest popupWithChoicesCreateRequest);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -4,6 +4,7 @@ import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
+import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.survey.domain.Choice;
 import com.lgcns.domain.survey.domain.Survey;
@@ -28,13 +29,16 @@ public class PopupServiceImpl implements PopupService {
     private final int MAX_SURVEY = 4;
 
     @Override
-    public void createPopup(PopupWithChoicesCreateRequest popupWithChoicesCreateRequest) {
+    public PopupCreateResponse createPopup(
+            PopupWithChoicesCreateRequest popupWithChoicesCreateRequest) {
         Manager manager = managerUtil.getCurrentManager();
         Popup popup =
                 createPopupFromRequest(manager, popupWithChoicesCreateRequest.popupCreateRequest());
         popupRepository.save(popup);
 
         createSurveyFromRequest(popup, popupWithChoicesCreateRequest.choiceCreateRequestList());
+
+        return PopupCreateResponse.of(popup.getId());
     }
 
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -8,6 +8,7 @@ import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
+import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.survey.domain.Choice;
 import com.lgcns.domain.survey.domain.Survey;
@@ -60,11 +61,12 @@ public class PopupServiceTest extends IntegrationTest {
                     createPopupWithChoicesCreateRequest();
 
             // when
-            popupService.createPopup(popupWithChoicesCreateRequest);
+            PopupCreateResponse response = popupService.createPopup(popupWithChoicesCreateRequest);
 
             // then
             Popup popup = popupRepository.findAll().get(0);
             Assertions.assertAll(
+                    () -> assertThat(response.popupId()).isEqualTo(popup.getId()),
                     () -> assertThat(popup.getName()).isEqualTo("popup1"),
                     () -> assertThat(popup.getImageUrl()).isEqualTo("https://bucket/asdf"),
                     () ->


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-106]

---
## 📌 작업 내용 및 특이사항

- 팝업 등록 -> 상품 등록 과정을 원활히 하기 위해 기존 void였던 팝업 등록 반환값을 popupId로 바꾸고 PopupCreateRequest에 담아서 보냈습니다.
- 이에 따라 테스트 코드에 id 검증도 추가했습니다.

---
## 📚 참고사항

[LCR-106]: https://lgcns-retail.atlassian.net/browse/LCR-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ