### PR TITLE
feat: 이미지 업로드용 Presigned URL 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ def jacocoExcludePatterns = [
         "**/resources/**",
         "**/exception/**",
         "**/config/**",
+        "**/controller/**",
         "**/*Auth*",
         "**/*Jwt*",
         "**/*Token*",

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // S3
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 }
 
 jar { enabled = true }

--- a/src/main/java/com/lgcns/domain/image/controller/ImageController.java
+++ b/src/main/java/com/lgcns/domain/image/controller/ImageController.java
@@ -20,11 +20,11 @@ public class ImageController {
 
     private final ImageService imageService;
 
+    @PostMapping("/presigned-url")
     @Operation(
             summary = "이미지 업로드용 Presigned URL 생성",
             description =
                     "디렉토리(popup/item)와 확장자(png/jpeg)에 따라 이미지를 업로드할 수 있는 Presigned URL을 생성합니다.")
-    @PostMapping("/presigned-url")
     public PresignedUrlResponse presignedUrlResponse(
             @Valid @RequestBody ImageUploadRequest request) {
         return imageService.createPresignedUrl(request);

--- a/src/main/java/com/lgcns/domain/image/controller/ImageController.java
+++ b/src/main/java/com/lgcns/domain/image/controller/ImageController.java
@@ -1,0 +1,32 @@
+package com.lgcns.domain.image.controller;
+
+import com.lgcns.domain.image.dto.request.ImageUploadRequest;
+import com.lgcns.domain.image.dto.response.PresignedUrlResponse;
+import com.lgcns.domain.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+@Tag(name = "2. 이미지 API", description = "이미지 관련 API입니다.")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @Operation(
+            summary = "이미지 업로드용 Presigned URL 생성",
+            description =
+                    "디렉토리(popup/item)와 확장자(png/jpeg)에 따라 이미지를 업로드할 수 있는 Presigned URL을 생성합니다.")
+    @PostMapping("/presigned-url")
+    public PresignedUrlResponse presignedUrlResponse(
+            @Valid @RequestBody ImageUploadRequest request) {
+        return imageService.createPresignedUrl(request);
+    }
+}

--- a/src/main/java/com/lgcns/domain/image/dto/ImageDirectory.java
+++ b/src/main/java/com/lgcns/domain/image/dto/ImageDirectory.java
@@ -1,0 +1,13 @@
+package com.lgcns.domain.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageDirectory {
+    POPUP("popup"),
+    ITEM("item");
+
+    private final String directory;
+}

--- a/src/main/java/com/lgcns/domain/image/dto/ImageFileExtension.java
+++ b/src/main/java/com/lgcns/domain/image/dto/ImageFileExtension.java
@@ -1,0 +1,15 @@
+package com.lgcns.domain.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageFileExtension {
+    PNG("png"),
+    JPG("jpg"),
+    JPEG("jpeg"),
+    ;
+
+    private final String extension;
+}

--- a/src/main/java/com/lgcns/domain/image/dto/request/ImageUploadRequest.java
+++ b/src/main/java/com/lgcns/domain/image/dto/request/ImageUploadRequest.java
@@ -1,0 +1,14 @@
+package com.lgcns.domain.image.dto.request;
+
+import com.lgcns.domain.image.dto.ImageDirectory;
+import com.lgcns.domain.image.dto.ImageFileExtension;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ImageUploadRequest(
+        @NotNull(message = "이미지 파일 확장자는 비워둘 수 없습니다.")
+                @Schema(description = "이미지 파일 확장자", defaultValue = "JPEG")
+                ImageFileExtension imageFileExtension,
+        @NotNull(message = "이미지 저장 디렉토리는 비워둘 수 없습니다.")
+                @Schema(description = "이미지를 저장할 디렉토리 (예: POPUP, ITEM)", defaultValue = "POPUP")
+                ImageDirectory imageDirectory) {}

--- a/src/main/java/com/lgcns/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/lgcns/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,5 @@
+package com.lgcns.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PresignedUrlResponse(@Schema(description = "Presigned URL") String presignedUrl) {}

--- a/src/main/java/com/lgcns/domain/image/service/ImageService.java
+++ b/src/main/java/com/lgcns/domain/image/service/ImageService.java
@@ -81,7 +81,7 @@ public class ImageService {
     private Date getPresignedUrlExpiration() {
         Date expiration = new Date();
         long expTime = expiration.getTime();
-        expTime += TimeUnit.MINUTES.toMillis(3);
+        expTime += TimeUnit.MINUTES.toMillis(1);
         expiration.setTime(expTime);
 
         return expiration;

--- a/src/main/java/com/lgcns/domain/image/service/ImageService.java
+++ b/src/main/java/com/lgcns/domain/image/service/ImageService.java
@@ -1,0 +1,89 @@
+package com.lgcns.domain.image.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.lgcns.domain.image.dto.ImageFileExtension;
+import com.lgcns.domain.image.dto.request.ImageUploadRequest;
+import com.lgcns.domain.image.dto.response.PresignedUrlResponse;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.global.util.ManagerUtil;
+import com.lgcns.infra.s3.S3Properties;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ManagerUtil managerUtil;
+    private final S3Properties s3Properties;
+    private final AmazonS3 amazonS3;
+
+    public PresignedUrlResponse createPresignedUrl(ImageUploadRequest request) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+
+        String imageKey = generateUUID();
+        String s3ObjectKey =
+                createS3ObjectKey(
+                        currentManager.getId(),
+                        request.imageDirectory().getDirectory(),
+                        imageKey,
+                        request.imageFileExtension());
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                generatePresignedUrlRequest(
+                        s3Properties.bucket(),
+                        s3ObjectKey,
+                        request.imageFileExtension().getExtension());
+
+        String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+
+        return new PresignedUrlResponse(presignedUrl);
+    }
+
+    private GeneratePresignedUrlRequest generatePresignedUrlRequest(
+            String bucket, String s3ObjectKey, String imageFileExtension) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, s3ObjectKey, HttpMethod.PUT)
+                        .withKey(s3ObjectKey)
+                        .withContentType("image/" + imageFileExtension)
+                        .withExpiration(getPresignedUrlExpiration());
+
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    private String generateUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String createS3ObjectKey(
+            Long managerId,
+            String directory,
+            String imageKey,
+            ImageFileExtension imageFileExtension) {
+        return managerId
+                + "/"
+                + directory
+                + "/"
+                + imageKey
+                + "."
+                + imageFileExtension.getExtension();
+    }
+
+    private Date getPresignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTime = expiration.getTime();
+        expTime += TimeUnit.MINUTES.toMillis(3);
+        expiration.setTime(expTime);
+
+        return expiration;
+    }
+}

--- a/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
+++ b/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
@@ -2,9 +2,10 @@ package com.lgcns.infra.properties;
 
 import com.lgcns.infra.jwt.JwtProperties;
 import com.lgcns.infra.redis.RedisProperties;
+import com.lgcns.infra.s3.S3Properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties({RedisProperties.class, JwtProperties.class})
+@EnableConfigurationProperties({RedisProperties.class, JwtProperties.class, S3Properties.class})
 @Configuration
 public class PropertiesConfig {}

--- a/src/main/java/com/lgcns/infra/s3/S3Config.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Config.java
@@ -1,0 +1,31 @@
+package com.lgcns.infra.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        BasicAWSCredentials credentials =
+                new BasicAWSCredentials(s3Properties.accessKey(), s3Properties.secretKey());
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                new AwsClientBuilder.EndpointConfiguration(
+                        s3Properties.endpoint(), s3Properties.region());
+
+        return AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/lgcns/infra/s3/S3Properties.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Properties.java
@@ -1,0 +1,7 @@
+package com.lgcns.infra.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cloud.aws")
+public record S3Properties(
+        String region, String accessKey, String secretKey, String bucket, String endpoint) {}

--- a/src/main/resources/application-s3.yml
+++ b/src/main/resources/application-s3.yml
@@ -1,0 +1,11 @@
+spring:
+  config:
+    activate:
+      on-profile: "s3"
+cloud:
+  aws:
+    region: ${AWS_REGION}
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
+    bucket: ${AWS_BUCKET}
+    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     include:
       - redis
       - security
+      - s3
 
 spring-doc:
   default-consumes-media-type: application/json

--- a/src/test/java/com/lgcns/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/lgcns/domain/image/service/ImageServiceTest.java
@@ -1,0 +1,72 @@
+package com.lgcns.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lgcns.IntegrationTest;
+import com.lgcns.domain.image.dto.ImageDirectory;
+import com.lgcns.domain.image.dto.ImageFileExtension;
+import com.lgcns.domain.image.dto.request.ImageUploadRequest;
+import com.lgcns.domain.image.dto.response.PresignedUrlResponse;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.global.security.PrincipalDetails;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class ImageServiceTest extends IntegrationTest {
+    @Autowired private ImageService imageService;
+    @Autowired private ManagerRepository managerRepository;
+
+    private Manager manager;
+
+    @BeforeEach
+    void setUp() {
+        manager = managerRepository.save(Manager.createManager("testUsername", "testPassword"));
+
+        UserDetails userDetails = new PrincipalDetails(manager.getId(), manager.getRole(), null);
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Nested
+    class 이미지_업로드용_Presigned_URL을_생성할_때 {
+        @Test
+        void 입력_값이_정상이라면_팝업_이미지_업로드용_Presigned_URL이_정상적으로_생성된다() {
+            // given
+            ImageUploadRequest request =
+                    new ImageUploadRequest(ImageFileExtension.JPEG, ImageDirectory.POPUP);
+
+            PresignedUrlResponse response = imageService.createPresignedUrl(request);
+
+            // when & then
+            assertThat(response.presignedUrl())
+                    .containsPattern(
+                            String.format(
+                                    "/%s/%s/[\\w\\-]+\\.jpeg",
+                                    manager.getId(), request.imageDirectory().getDirectory()));
+        }
+
+        @Test
+        void 입력_값이_정상이라면_상품_이미지_업로드용_Presigned_URL이_정상적으로_생성된다() {
+            // given
+            ImageUploadRequest request =
+                    new ImageUploadRequest(ImageFileExtension.JPEG, ImageDirectory.ITEM);
+
+            PresignedUrlResponse response = imageService.createPresignedUrl(request);
+
+            // when & then
+            assertThat(response.presignedUrl())
+                    .containsPattern(
+                            String.format(
+                                    "/%s/%s/[\\w\\-]+\\.jpeg",
+                                    manager.getId(), request.imageDirectory().getDirectory()));
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-63]

---
## 📌 작업 내용 및 특이사항

- 팝업, 상품의 이미지 업로드용 Presigned URL 생성 기능을 구현했습니다.
- Presigned URL 생성 시 만료 시간을 1분으로 설정했습니다.
- S3 버킷 정책 및 CORS 설정을 적용하였습니다.
- Jacoco 커버리지 제외 패턴에 controller 경로를 추가했습니다.
  - 컨트롤러 단위 테스트는 작성하지 않을 계획이므로 측정 대상에서 제외하였습니다.

---
## 📚 참고사항

- .env 파일에 들어갈 환경변수는 따로 공유드리겠습니다.


[LCR-63]: https://lgcns-retail.atlassian.net/browse/LCR-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ