### PR TITLE
feat: 상품 최소 발주 수량 수정 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/controller/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/controller/ItemController.java
@@ -62,6 +62,6 @@ public class ItemController {
             @PathVariable Long popupId,
             @PathVariable Long itemId,
             @Valid @RequestBody ItemMinStockUpdateRequest request) {
-        return itemService.updateItemMinStock(popupId, itemId, request.minStock());
+        return itemService.updateItemMinStock(popupId, itemId, request);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/controller/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/controller/ItemController.java
@@ -1,6 +1,8 @@
 package com.lgcns.domain.item.controller;
 
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
+import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import com.lgcns.domain.item.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,5 +54,14 @@ public class ItemController {
     public ResponseEntity<Void> itemDelete(@PathVariable Long popupId, @PathVariable Long itemId) {
         itemService.deleteItem(popupId, itemId);
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PatchMapping("/{itemId}")
+    @Operation(summary = "상품 최소 발주 수량 수정", description = "선택한 상품의 최소 발주 수량을 설정한 값으로 수정합니다.")
+    public ItemDetailResponse itemMinStockUpdate(
+            @PathVariable Long popupId,
+            @PathVariable Long itemId,
+            @Valid @RequestBody ItemMinStockUpdateRequest request) {
+        return itemService.updateItemMinStock(popupId, itemId, request.minStock());
     }
 }

--- a/src/main/java/com/lgcns/domain/item/domain/Item.java
+++ b/src/main/java/com/lgcns/domain/item/domain/Item.java
@@ -70,4 +70,8 @@ public class Item extends BaseTimeEntity {
                 .location(location)
                 .build();
     }
+
+    public void updateMinStock(int minStock) {
+        this.minStock = minStock;
+    }
 }

--- a/src/main/java/com/lgcns/domain/item/dto/request/ItemMinStockUpdateRequest.java
+++ b/src/main/java/com/lgcns/domain/item/dto/request/ItemMinStockUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.lgcns.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ItemMinStockUpdateRequest(
+        @Schema(description = "상품 최소 발주 수량", example = "30")
+                @NotNull(message = "최소 발주 수량은 필수 입력 항목입니다.")
+                @Min(value = 0, message = "최소 발주 수량은 0 이상이어야 합니다.")
+                Integer minStock) {}

--- a/src/main/java/com/lgcns/domain/item/dto/response/ItemDetailResponse.java
+++ b/src/main/java/com/lgcns/domain/item/dto/response/ItemDetailResponse.java
@@ -1,0 +1,26 @@
+package com.lgcns.domain.item.dto.response;
+
+import com.lgcns.domain.item.domain.Item;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ItemDetailResponse(
+        @Schema(description = "상품 ID", example = "1") Long id,
+        @Schema(description = "팝업 ID", example = "1") Long popupId,
+        @Schema(description = "상품명", example = "지수 포토카드") String name,
+        @Schema(description = "상품 이미지 URL", example = "https://bucket/asdf.jpg") String imageUrl,
+        @Schema(description = "상품 가격", example = "50000") int price,
+        @Schema(description = "상품 재고 수량", example = "50") int stock,
+        @Schema(description = "상품 최소 발주 수량", example = "30") int minStock,
+        @Schema(description = "상품 위치", example = "a1") String location) {
+    public static ItemDetailResponse from(Item item) {
+        return new ItemDetailResponse(
+                item.getId(),
+                item.getPopup().getId(),
+                item.getName(),
+                item.getImageUrl(),
+                item.getPrice(),
+                item.getStock(),
+                item.getMinStock(),
+                item.getLocation());
+    }
+}

--- a/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
+++ b/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ItemErrorCode implements ErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 상품을 찾을 수 없습니다."),
-    ITEM_POPUP_MISMATCH(HttpStatus.BAD_REQUEST, "해당 팝업에 등록된 상품이 아닙니다.");
+    ITEM_POPUP_MISMATCH(HttpStatus.BAD_REQUEST, "해당 팝업에 등록된 상품이 아닙니다."),
+    MIN_STOCK_EXCEEDED(HttpStatus.BAD_REQUEST, "최소 발주 수량은 재고 수량보다 크게 설정할 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.item.service;
 
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import java.io.IOException;
@@ -20,5 +21,6 @@ public interface ItemService {
 
     void deleteItem(Long popupId, Long itemId);
 
-    ItemDetailResponse updateItemMinStock(Long popupId, Long itemId, int minStock);
+    ItemDetailResponse updateItemMinStock(
+            Long popupId, Long itemId, ItemMinStockUpdateRequest request);
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.item.service;
 
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import java.io.IOException;
 import java.util.List;
@@ -18,4 +19,6 @@ public interface ItemService {
     Map<String, List<ItemPreviewResponse>> findAllItems(Long popupId);
 
     void deleteItem(Long popupId, Long itemId);
+
+    ItemDetailResponse updateItemMinStock(Long popupId, Long itemId, int minStock);
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.item.service;
 
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import com.lgcns.domain.item.exception.ItemErrorCode;
@@ -152,5 +153,27 @@ public class ItemServiceImpl implements ItemService {
         return itemRepository
                 .findById(itemId)
                 .orElseThrow(() -> new CustomException(ItemErrorCode.ITEM_NOT_FOUND));
+    }
+
+    private void validateMinStock(Item item, int minStock) {
+        if (minStock > item.getStock()) {
+            throw new CustomException(ItemErrorCode.MIN_STOCK_EXCEEDED);
+        }
+    }
+
+    @Override
+    public ItemDetailResponse updateItemMinStock(Long popupId, Long itemId, int minStock) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+        final Popup popup = findPopupById(popupId);
+        validatePopupOwnership(currentManager, popup);
+
+        final Item item = findByItemId(itemId);
+        validateItemBelongsToPopup(item, popupId);
+
+        validateMinStock(item, minStock);
+
+        item.updateMinStock(minStock);
+
+        return ItemDetailResponse.from(item);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.item.service;
 
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
@@ -162,7 +163,8 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
-    public ItemDetailResponse updateItemMinStock(Long popupId, Long itemId, int minStock) {
+    public ItemDetailResponse updateItemMinStock(
+            Long popupId, Long itemId, ItemMinStockUpdateRequest request) {
         final Manager currentManager = managerUtil.getCurrentManager();
         final Popup popup = findPopupById(popupId);
         validatePopupOwnership(currentManager, popup);
@@ -170,9 +172,9 @@ public class ItemServiceImpl implements ItemService {
         final Item item = findByItemId(itemId);
         validateItemBelongsToPopup(item, popupId);
 
-        validateMinStock(item, minStock);
+        validateMinStock(item, request.minStock());
 
-        item.updateMinStock(minStock);
+        item.updateMinStock(request.minStock());
 
         return ItemDetailResponse.from(item);
     }

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import com.lgcns.domain.item.exception.ItemErrorCode;
@@ -459,18 +460,17 @@ class ItemServiceTest extends IntegrationTest {
             Item savedItem = createTestItem(); // 기본 minStock = 10
             final Long popupId = popup.getId();
             final Long itemId = savedItem.getId();
-            final int newMinStock = 30;
+            ItemMinStockUpdateRequest request = new ItemMinStockUpdateRequest(30);
 
             // when
-            ItemDetailResponse response =
-                    itemService.updateItemMinStock(popupId, itemId, newMinStock);
+            ItemDetailResponse response = itemService.updateItemMinStock(popupId, itemId, request);
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.minStock()).isEqualTo(newMinStock);
+            assertThat(response.minStock()).isEqualTo(request.minStock());
 
             Item updatedItem = itemRepository.findById(itemId).orElseThrow();
-            assertThat(updatedItem.getMinStock()).isEqualTo(newMinStock);
+            assertThat(updatedItem.getMinStock()).isEqualTo(request.minStock());
         }
 
         @Test
@@ -480,11 +480,10 @@ class ItemServiceTest extends IntegrationTest {
             Item savedItem = createTestItem();
             Long popupId = popup.getId();
             Long itemId = savedItem.getId();
-            int newMinStock = 30;
+            ItemMinStockUpdateRequest request = new ItemMinStockUpdateRequest(30);
 
             // when
-            ItemDetailResponse response =
-                    itemService.updateItemMinStock(popupId, itemId, newMinStock);
+            ItemDetailResponse response = itemService.updateItemMinStock(popupId, itemId, request);
 
             // then
             assertThat(response).isNotNull();
@@ -496,7 +495,7 @@ class ItemServiceTest extends IntegrationTest {
                     () -> assertThat(response.imageUrl()).isEqualTo(savedItem.getImageUrl()),
                     () -> assertThat(response.price()).isEqualTo(savedItem.getPrice()),
                     () -> assertThat(response.stock()).isEqualTo(savedItem.getStock()),
-                    () -> assertThat(response.minStock()).isEqualTo(newMinStock),
+                    () -> assertThat(response.minStock()).isEqualTo(request.minStock()),
                     () -> assertThat(response.location()).isEqualTo(savedItem.getLocation()));
         }
 
@@ -504,15 +503,15 @@ class ItemServiceTest extends IntegrationTest {
         @Transactional
         void 존재하지_않는_상품의_최소_발주_수량을_수정하면_예외가_발생한다() {
             // given
-            Long popupId = popup.getId();
-            Long nonExistentItemId = 9999L;
-            int newMinStock = 30;
+            final Long popupId = popup.getId();
+            final Long nonExistentItemId = 9999L;
+            ItemMinStockUpdateRequest request = new ItemMinStockUpdateRequest(30);
 
             // when & then
             assertThatThrownBy(
                             () ->
                                     itemService.updateItemMinStock(
-                                            popupId, nonExistentItemId, newMinStock))
+                                            popupId, nonExistentItemId, request))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.ITEM_NOT_FOUND);
         }
@@ -523,7 +522,7 @@ class ItemServiceTest extends IntegrationTest {
             // given
             Item savedItem = createTestItem();
             Long popupId = popup.getId();
-            int newMinStock = 30;
+            ItemMinStockUpdateRequest request = new ItemMinStockUpdateRequest(30);
 
             // 다른 관리자로 로그인
             setAuthentication(otherManager);
@@ -532,7 +531,7 @@ class ItemServiceTest extends IntegrationTest {
             assertThatThrownBy(
                             () ->
                                     itemService.updateItemMinStock(
-                                            popupId, savedItem.getId(), newMinStock))
+                                            popupId, savedItem.getId(), request))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
         }
@@ -542,7 +541,7 @@ class ItemServiceTest extends IntegrationTest {
         void 상품이_해당_팝업에_속하지_않으면_예외가_발생한다() {
             // given
             Item savedItem = createTestItem();
-            int newMinStock = 30;
+            ItemMinStockUpdateRequest request = new ItemMinStockUpdateRequest(30);
 
             // 다른 팝업 ID 사용
             Long wrongPopupId = otherPopup.getId();
@@ -551,7 +550,7 @@ class ItemServiceTest extends IntegrationTest {
             assertThatThrownBy(
                             () ->
                                     itemService.updateItemMinStock(
-                                            wrongPopupId, savedItem.getId(), newMinStock))
+                                            wrongPopupId, savedItem.getId(), request))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.ITEM_POPUP_MISMATCH);
         }
@@ -561,14 +560,14 @@ class ItemServiceTest extends IntegrationTest {
         void 최소_발주_수량이_재고보다_크면_예외가_발생한다() {
             // given
             Item savedItem = createTestItem(); // stock = 100
-            Long popupId = popup.getId();
-            int invalidMinStock = 150; // 재고(100)보다 큰 값
+            final Long popupId = popup.getId();
+            ItemMinStockUpdateRequest request = new ItemMinStockUpdateRequest(150); // 재고(100)보다 큰 값
 
             // when & then
             assertThatThrownBy(
                             () ->
                                     itemService.updateItemMinStock(
-                                            popupId, savedItem.getId(), invalidMinStock))
+                                            popupId, savedItem.getId(), request))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.MIN_STOCK_EXCEEDED);
         }

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
+import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import com.lgcns.domain.item.exception.ItemErrorCode;
 import com.lgcns.domain.item.repository.ItemRepository;
@@ -45,6 +46,7 @@ class ItemServiceTest extends IntegrationTest {
     private Manager ownerManager;
     private Manager otherManager;
     private Popup popup;
+    private Popup otherPopup;
 
     private Item createTestItem() {
         return itemRepository.save(
@@ -78,6 +80,25 @@ class ItemServiceTest extends IntegrationTest {
                         37.123456,
                         127.123456);
         popup = popupRepository.save(popup);
+
+        otherPopup =
+                Popup.createPopup(
+                        ownerManager,
+                        "testPopup2",
+                        "https://bucket/이미지2.jpg",
+                        LocalDate.parse("2025-01-11"),
+                        LocalDate.parse("2025-02-20"),
+                        LocalDateTime.parse("2025-01-01T10:00:00"),
+                        LocalDateTime.parse("2025-01-31T20:00:00"),
+                        LocalTime.parse("10:00:00"),
+                        LocalTime.parse("20:00:00"),
+                        200,
+                        30,
+                        "인천광역시 서구 비즈니스로 123",
+                        "16층 1601호",
+                        39.123456,
+                        129.123456);
+        otherPopup = popupRepository.save(otherPopup);
     }
 
     @Nested
@@ -266,7 +287,7 @@ class ItemServiceTest extends IntegrationTest {
         @Transactional
         void 상품_목록_조회에_성공한다() {
             // given
-            Long popupId = popup.getId();
+            final Long popupId = popup.getId();
 
             Item item1 =
                     Item.createItem(
@@ -420,31 +441,136 @@ class ItemServiceTest extends IntegrationTest {
             // given
             Item savedItem = createTestItem();
 
-            Popup anotherPopup =
-                    Popup.createPopup(
-                            ownerManager, // 동일한 관리자
-                            "anotherPopup",
-                            "https://bucket/another.jpg",
-                            LocalDate.parse("2025-01-01"),
-                            LocalDate.parse("2025-01-31"),
-                            LocalDateTime.parse("2025-01-01T10:00:00"),
-                            LocalDateTime.parse("2025-01-31T20:00:00"),
-                            LocalTime.parse("10:00:00"),
-                            LocalTime.parse("20:00:00"),
-                            100,
-                            20,
-                            "서울특별시 강남구 테헤란로 456",
-                            "5층 B호",
-                            37.654321,
-                            127.654321);
-            Popup savedAnotherPopup = popupRepository.save(anotherPopup);
-
-            Long wrongPopupId = savedAnotherPopup.getId();
+            Long wrongPopupId = otherPopup.getId();
 
             // when & then
             assertThatThrownBy(() -> itemService.deleteItem(wrongPopupId, savedItem.getId()))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.ITEM_POPUP_MISMATCH);
+        }
+    }
+
+    @Nested
+    class 상품_최소_발주_수량_수정 {
+        @Test
+        @Transactional
+        void 정상적으로_최소_발주_수량_수정에_성공한다() {
+            // given
+            Item savedItem = createTestItem(); // 기본 minStock = 10
+            final Long popupId = popup.getId();
+            final Long itemId = savedItem.getId();
+            final int newMinStock = 30;
+
+            // when
+            ItemDetailResponse response =
+                    itemService.updateItemMinStock(popupId, itemId, newMinStock);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.minStock()).isEqualTo(newMinStock);
+
+            Item updatedItem = itemRepository.findById(itemId).orElseThrow();
+            assertThat(updatedItem.getMinStock()).isEqualTo(newMinStock);
+        }
+
+        @Test
+        @Transactional
+        void 성공_응답에_알맞은_상품_정보가_포함되어있다() {
+            // given
+            Item savedItem = createTestItem();
+            Long popupId = popup.getId();
+            Long itemId = savedItem.getId();
+            int newMinStock = 30;
+
+            // when
+            ItemDetailResponse response =
+                    itemService.updateItemMinStock(popupId, itemId, newMinStock);
+
+            // then
+            assertThat(response).isNotNull();
+
+            Assertions.assertAll(
+                    () -> assertThat(response.id()).isEqualTo(savedItem.getId()),
+                    () -> assertThat(response.popupId()).isEqualTo(popupId),
+                    () -> assertThat(response.name()).isEqualTo(savedItem.getName()),
+                    () -> assertThat(response.imageUrl()).isEqualTo(savedItem.getImageUrl()),
+                    () -> assertThat(response.price()).isEqualTo(savedItem.getPrice()),
+                    () -> assertThat(response.stock()).isEqualTo(savedItem.getStock()),
+                    () -> assertThat(response.minStock()).isEqualTo(newMinStock),
+                    () -> assertThat(response.location()).isEqualTo(savedItem.getLocation()));
+        }
+
+        @Test
+        @Transactional
+        void 존재하지_않는_상품의_최소_발주_수량을_수정하면_예외가_발생한다() {
+            // given
+            Long popupId = popup.getId();
+            Long nonExistentItemId = 9999L;
+            int newMinStock = 30;
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    itemService.updateItemMinStock(
+                                            popupId, nonExistentItemId, newMinStock))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.ITEM_NOT_FOUND);
+        }
+
+        @Test
+        @Transactional
+        void 권한이_없는_사용자가_최소_발주_수량을_수정하면_예외가_발생한다() {
+            // given
+            Item savedItem = createTestItem();
+            Long popupId = popup.getId();
+            int newMinStock = 30;
+
+            // 다른 관리자로 로그인
+            setAuthentication(otherManager);
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    itemService.updateItemMinStock(
+                                            popupId, savedItem.getId(), newMinStock))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
+        }
+
+        @Test
+        @Transactional
+        void 상품이_해당_팝업에_속하지_않으면_예외가_발생한다() {
+            // given
+            Item savedItem = createTestItem();
+            int newMinStock = 30;
+
+            // 다른 팝업 ID 사용
+            Long wrongPopupId = otherPopup.getId();
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    itemService.updateItemMinStock(
+                                            wrongPopupId, savedItem.getId(), newMinStock))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.ITEM_POPUP_MISMATCH);
+        }
+
+        @Test
+        @Transactional
+        void 최소_발주_수량이_재고보다_크면_예외가_발생한다() {
+            // given
+            Item savedItem = createTestItem(); // stock = 100
+            Long popupId = popup.getId();
+            int invalidMinStock = 150; // 재고(100)보다 큰 값
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    itemService.updateItemMinStock(
+                                            popupId, savedItem.getId(), invalidMinStock))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.MIN_STOCK_EXCEEDED);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-118]

---
## 📌 작업 내용 및 특이사항

- 상품의 최소 발주 수량을 수정하는 API를 구현했습니다.
- 하나의 필드에 대해 업데이틀르 진행하므로 PATCH 메서드로 구현했습니다.
- 수정할 최소 발주 수량은 request body로 받아서 처리했습니다.
- 수정 요청 시 최대 설정 수량이 현재 재고 수량을 초과 할 경우 MIN_STOCK_EXCEEDED 에러를 발생합니다.
- 응답 반환 값으로 200과 상품의 모든 엔티티를 반환합니다.
- 반환 값의 location 값은 DB에 저장된 상태 그대로 반환합니다. ex("a1")

### 응답 예시
> 성공
```json
{
    "success": true,
    "status": 200,
    "data": {
        "id": 8,
        "popupId": 2,
        "name": "안유진 포토카드",
        "imageUrl": "aws.bucket.상품사진",
        "price": 50000,
        "stock": 100,
        "minStock": 50,
        "location": "a2"
    },
    "timestamp": "2025-05-10T14:59:46.123184"
}
```

> 실패
- 수정하려는 최소 발주 수량이 재고를 초과하는 경우
```json
{
    "success": false,
    "status": 400,
    "data": {
        "errorClassName": "MIN_STOCK_EXCEEDED",
        "message": "최소 발주 수량은 재고 수량보다 크게 설정할 수 없습니다."
    },
    "timestamp": "2025-05-10T15:06:05.602977"
}
```

- 존재하지 않는 상품에 대한 요청
```json
{
    "success": false,
    "status": 404,
    "data": {
        "errorClassName": "ITEM_NOT_FOUND",
        "message": "해당 상품을 찾을 수 없습니다."
    },
    "timestamp": "2025-05-10T15:03:04.124838"
}
```

- 해당 팝업에 등록된 상품이 아닌 경우
```json
{
    "success": false,
    "status": 400,
    "data": {
        "errorClassName": "ITEM_POPUP_MISMATCH",
        "message": "해당 팝업에 등록된 상품이 아닙니다."
    },
    "timestamp": "2025-05-10T15:05:02.927698"
}
```

- 해당 팝업의 소유권이 없는 사용자의 요청
```json
{
    "success": false,
    "status": 403,
    "data": {
        "errorClassName": "POPUP_UNAUTHORIZED",
        "message": "해당 팝업의 소유자가 아닙니다."
    },
    "timestamp": "2025-05-10T15:04:01.171952"
}
```

---
## 📚 참고사항

- 


[LCR-118]: https://lgcns-retail.atlassian.net/browse/LCR-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ