### PR TITLE
fix: dev 환경 CORS 및 쿠키 미발급 문제 수정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/src/main/java/com/lgcns/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/lgcns/global/common/constants/UrlConstants.java
@@ -1,0 +1,9 @@
+package com.lgcns.global.common.constants;
+
+public final class UrlConstants {
+    public static final String DEV_CLIENT_URL = "https://www.dev.ceo.popi.today";
+    public static final String LOCAL_CLIENT_URL = "http://localhost:3000";
+
+    public static final String DEV_SERVER_URL = "https://dev-api.ceo.popi.today";
+    public static final String LOCAL_SERVER_URL = "http://localhost:8080";
+}

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -1,9 +1,12 @@
 package com.lgcns.global.config.security;
 
+import static com.lgcns.global.common.constants.UrlConstants.DEV_CLIENT_URL;
+import static com.lgcns.global.common.constants.UrlConstants.LOCAL_CLIENT_URL;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 import com.lgcns.domain.auth.service.JwtTokenService;
+import com.lgcns.global.helper.SpringEnvironmentHelper;
 import com.lgcns.global.security.*;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 
+    private final SpringEnvironmentHelper springEnvironmentHelper;
     private final Validator validator;
     private final CustomUserDetailsService customUserDetailsService;
     private final LoginSuccessHandler loginSuccessHandler;
@@ -92,6 +96,11 @@ public class WebSecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
+
+        if (springEnvironmentHelper.isDevProfile()) {
+            configuration.addAllowedOriginPattern(DEV_CLIENT_URL);
+            configuration.addAllowedOriginPattern(LOCAL_CLIENT_URL);
+        }
 
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -1,7 +1,6 @@
 package com.lgcns.global.config.security;
 
-import static com.lgcns.global.common.constants.UrlConstants.DEV_CLIENT_URL;
-import static com.lgcns.global.common.constants.UrlConstants.LOCAL_CLIENT_URL;
+import static com.lgcns.global.common.constants.UrlConstants.*;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -98,6 +97,7 @@ public class WebSecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         if (springEnvironmentHelper.isDevProfile()) {
+            configuration.addAllowedOriginPattern(DEV_SERVER_URL);
             configuration.addAllowedOriginPattern(DEV_CLIENT_URL);
             configuration.addAllowedOriginPattern(LOCAL_CLIENT_URL);
         }

--- a/src/main/java/com/lgcns/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/lgcns/global/config/swagger/SwaggerConfig.java
@@ -1,10 +1,17 @@
 package com.lgcns.global.config.swagger;
 
+import static com.lgcns.global.common.constants.UrlConstants.DEV_SERVER_URL;
+import static com.lgcns.global.common.constants.UrlConstants.LOCAL_SERVER_URL;
+import static com.lgcns.global.helper.SpringEnvironmentHelper.DEV;
+
+import com.lgcns.global.helper.SpringEnvironmentHelper;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +22,8 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 public class SwaggerConfig {
 
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
@@ -23,8 +32,20 @@ public class SwaggerConfig {
                                 .title("PoPI Manager Server API")
                                 .description("PoPI Manager Server API 명세서입니다.")
                                 .version("v0.0.1"))
+                .servers(getSwaggerServers())
                 .components(authSetting())
                 .addSecurityItem(securityRequirement());
+    }
+
+    private List<Server> getSwaggerServers() {
+        return List.of(new Server().url(getServerUrlByProfile()));
+    }
+
+    private String getServerUrlByProfile() {
+        return switch (springEnvironmentHelper.getCurrentProfile()) {
+            case DEV -> DEV_SERVER_URL;
+            default -> LOCAL_SERVER_URL;
+        };
     }
 
     private Components authSetting() {

--- a/src/main/java/com/lgcns/global/helper/SpringEnvironmentHelper.java
+++ b/src/main/java/com/lgcns/global/helper/SpringEnvironmentHelper.java
@@ -1,0 +1,29 @@
+package com.lgcns.global.helper;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringEnvironmentHelper {
+
+    private final Environment environment;
+
+    public static final String DEV = "dev";
+    public static final String LOCAL = "local";
+
+    public String getCurrentProfile() {
+        return getActiveProfiles().filter(profile -> profile.equals(DEV)).findFirst().orElse(LOCAL);
+    }
+
+    public Boolean isDevProfile() {
+        return getActiveProfiles().anyMatch(DEV::equals);
+    }
+
+    private Stream<String> getActiveProfiles() {
+        return Arrays.stream(environment.getActiveProfiles());
+    }
+}

--- a/src/main/java/com/lgcns/global/util/CookieUtil.java
+++ b/src/main/java/com/lgcns/global/util/CookieUtil.java
@@ -1,19 +1,26 @@
 package com.lgcns.global.util;
 
 import static com.lgcns.global.common.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+import static com.lgcns.global.helper.SpringEnvironmentHelper.DEV;
 
+import com.lgcns.global.helper.SpringEnvironmentHelper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtil {
+
+    private final SpringEnvironmentHelper springEnvironmentHelper;
 
     public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
         ResponseCookie refreshTokenCookie =
                 ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                         .path("/")
+                        .domain(getCookieDomain())
                         .secure(true)
                         .sameSite(Cookie.SameSite.NONE.attributeValue())
                         .httpOnly(true)
@@ -23,5 +30,12 @@ public class CookieUtil {
         headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         return headers;
+    }
+
+    private String getCookieDomain() {
+        return switch (springEnvironmentHelper.getCurrentProfile()) {
+            case DEV -> ".ceo.popi.today";
+            default -> "localhost";
+        };
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-123]

---
## 📌 작업 내용 및 특이사항

- 클라이언트/서버 도메인을 구분해서 사용할 수 있도록 공통 URL 상수 클래스를 생성했습니다.
- SpringEnvironmentHelper를 도입하여 환경에 따라 분기 가능하도록 처리했습니다.
- dev 환경에서 쿠키가 발급되지 않는 문제를 해결하기 위해 ```domain=.ceo.popi.today``` 설정을 추가했습니다.
- dev 환경에서 CORS 허용 도메인에 local 및 dev 클라이언트 도메인을 포함하도록 하였습니다.
- Swagger 문서의 Try it out 기능이 실행 환경(local/dev)에 따라 올바른 API 서버로 요청을 보낼 수 있도록 servers URL을 실행 환경에 따라 분기 설정했습니다.
- 또한 Swagger UI가 dev-api.ceo.popi.today에서 열리므로, 해당 origin만 CORS에 명시적으로 허용하여 Try it out 요청이 차단되지 않도록 했습니다.

---
## 📚 참고사항

- prod 환경은 추후 도입할 예정입니다.


[LCR-123]: https://lgcns-retail.atlassian.net/browse/LCR-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ