### PR TITLE
feat: 팝업 삭제 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -101,12 +101,6 @@ public class ItemServiceImpl implements ItemService {
         }
     }
 
-    private Popup findPopupById(Long popupId) {
-        return popupRepository
-                .findById(popupId)
-                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
-    }
-
     @Override
     public Map<String, List<ItemPreviewResponse>> findAllItems(Long popupId) {
         List<ItemLocationResponse> projections = itemRepository.findItemsWithSplitLocation(popupId);
@@ -114,15 +108,21 @@ public class ItemServiceImpl implements ItemService {
         return groupItemsByLocation(projections);
     }
 
-    private Map<String, List<ItemPreviewResponse>> groupItemsByLocation(
-            List<ItemLocationResponse> projections) {
-        return projections.stream()
-                .collect(
-                        Collectors.groupingBy(
-                                ItemLocationResponse::locationGroup,
-                                Collectors.mapping(
-                                        ItemLocationResponse::toPreviewResponse,
-                                        Collectors.toList())));
+    @Override
+    public ItemDetailResponse updateItemMinStock(
+            Long popupId, Long itemId, ItemMinStockUpdateRequest request) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+        final Popup popup = findPopupById(popupId);
+        validatePopupOwnership(currentManager, popup);
+
+        final Item item = findByItemId(itemId);
+        validateItemBelongsToPopup(item, popupId);
+
+        validateMinStock(item, request.minStock());
+
+        item.updateMinStock(request.minStock());
+
+        return ItemDetailResponse.from(item);
     }
 
     @Override
@@ -136,6 +136,23 @@ public class ItemServiceImpl implements ItemService {
         validateItemBelongsToPopup(item, popupId);
 
         itemRepository.delete(item);
+    }
+
+    private Popup findPopupById(Long popupId) {
+        return popupRepository
+                .findById(popupId)
+                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
+    }
+
+    private Map<String, List<ItemPreviewResponse>> groupItemsByLocation(
+            List<ItemLocationResponse> projections) {
+        return projections.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                ItemLocationResponse::locationGroup,
+                                Collectors.mapping(
+                                        ItemLocationResponse::toPreviewResponse,
+                                        Collectors.toList())));
     }
 
     private void validatePopupOwnership(Manager manager, Popup popup) {
@@ -160,22 +177,5 @@ public class ItemServiceImpl implements ItemService {
         if (minStock > item.getStock()) {
             throw new CustomException(ItemErrorCode.MIN_STOCK_EXCEEDED);
         }
-    }
-
-    @Override
-    public ItemDetailResponse updateItemMinStock(
-            Long popupId, Long itemId, ItemMinStockUpdateRequest request) {
-        final Manager currentManager = managerUtil.getCurrentManager();
-        final Popup popup = findPopupById(popupId);
-        validatePopupOwnership(currentManager, popup);
-
-        final Item item = findByItemId(itemId);
-        validateItemBelongsToPopup(item, popupId);
-
-        validateMinStock(item, request.minStock());
-
-        item.updateMinStock(request.minStock());
-
-        return ItemDetailResponse.from(item);
     }
 }

--- a/src/main/java/com/lgcns/domain/popup/controller/PopupController.java
+++ b/src/main/java/com/lgcns/domain/popup/controller/PopupController.java
@@ -34,4 +34,11 @@ public class PopupController {
     public List<PopupPreviewResponse> popupFindAll() {
         return popupService.findAllPopups();
     }
+
+    @DeleteMapping("/{popupId}")
+    @Operation(summary = "팝업 삭제", description = "로그인한 운영자 소유의 팝업 하나를 삭제합니다.")
+    public ResponseEntity<Void> popupDelete(@PathVariable Long popupId) {
+        popupService.deletePopup(popupId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -9,4 +9,6 @@ public interface PopupService {
     PopupCreateResponse createPopup(PopupWithChoicesCreateRequest popupWithChoicesCreateRequest);
 
     List<PopupPreviewResponse> findAllPopups();
+
+    void deletePopup(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -6,12 +6,14 @@ import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.survey.domain.Choice;
 import com.lgcns.domain.survey.domain.Survey;
 import com.lgcns.domain.survey.dto.request.ChoiceCreateRequest;
 import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
+import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +51,16 @@ public class PopupServiceImpl implements PopupService {
         return popupRepository.findAllPopupsByManagerId(managerId);
     }
 
+    @Override
+    public void deletePopup(Long popupId) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+        final Popup popup = findPopupById(popupId);
+
+        validatePopupOwnership(currentManager, popup);
+
+        popupRepository.delete(popup);
+    }
+
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {
 
         return Popup.createPopup(
@@ -82,5 +94,17 @@ public class PopupServiceImpl implements PopupService {
             Choice choice = Choice.createChoice(survey, option);
             choiceRepository.save(choice);
         }
+    }
+
+    private void validatePopupOwnership(Manager manager, Popup popup) {
+        if (!popup.getManager().equals(manager)) {
+            throw new CustomException(PopupErrorCode.POPUP_UNAUTHORIZED);
+        }
+    }
+
+    private Popup findPopupById(Long popupId) {
+        return popupRepository
+                .findById(popupId)
+                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
     }
 }

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -21,7 +21,6 @@ import com.lgcns.domain.survey.dto.request.ChoiceCreateRequest;
 import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
 import com.lgcns.global.error.exception.CustomException;
-import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -42,8 +41,6 @@ public class PopupServiceTest extends IntegrationTest {
     @Autowired private ManagerRepository managerRepository;
     @Autowired private ChoiceRepository choiceRepository;
     @Autowired ItemRepository itemRepository;
-
-    @Autowired EntityManager entityManager;
 
     private Manager ownerManager;
     private Manager otherManager;

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -1,8 +1,11 @@
 package com.lgcns.domain.popup.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.lgcns.IntegrationTest;
+import com.lgcns.domain.item.repository.ItemRepository;
+import com.lgcns.domain.item.service.ItemService;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.popup.domain.Popup;
@@ -10,13 +13,15 @@ import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.survey.domain.Choice;
 import com.lgcns.domain.survey.domain.Survey;
 import com.lgcns.domain.survey.dto.request.ChoiceCreateRequest;
 import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
-import com.lgcns.global.security.PrincipalDetails;
+import com.lgcns.global.error.exception.CustomException;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -26,30 +31,32 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 
 public class PopupServiceTest extends IntegrationTest {
     @Autowired PopupService popupService;
+    @Autowired ItemService itemService;
     @Autowired PopupRepository popupRepository;
     @Autowired SurveyRepository surveyRepository;
 
     @Autowired private ManagerRepository managerRepository;
     @Autowired private ChoiceRepository choiceRepository;
+    @Autowired ItemRepository itemRepository;
 
-    private Manager manager;
+    @Autowired EntityManager entityManager;
+
+    private Manager ownerManager;
+    private Manager otherManager;
+    private Popup popup;
 
     @BeforeEach
     void setUp() {
-        manager = managerRepository.save(Manager.createManager("testUsername", "testPassword"));
+        ownerManager =
+                managerRepository.save(Manager.createManager("testUsername", "testPassword"));
+        otherManager =
+                managerRepository.save(Manager.createManager("otherManager", "testPassword"));
 
-        UserDetails userDetails = new PrincipalDetails(manager.getId(), manager.getRole(), null);
-        UsernamePasswordAuthenticationToken token =
-                new UsernamePasswordAuthenticationToken(
-                        userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(token);
+        setAuthentication(ownerManager);
     }
 
     @Nested
@@ -65,20 +72,20 @@ public class PopupServiceTest extends IntegrationTest {
             PopupCreateResponse response = popupService.createPopup(popupWithChoicesCreateRequest);
 
             // then
-            Popup popup = popupRepository.findAll().get(0);
+            Popup savedPopup = popupRepository.findById(response.popupId()).orElseThrow();
             Assertions.assertAll(
-                    () -> assertThat(response.popupId()).isEqualTo(popup.getId()),
-                    () -> assertThat(popup.getName()).isEqualTo("popup1"),
-                    () -> assertThat(popup.getImageUrl()).isEqualTo("https://bucket/asdf"),
+                    () -> assertThat(response.popupId()).isEqualTo(savedPopup.getId()),
+                    () -> assertThat(savedPopup.getName()).isEqualTo("popup1"),
+                    () -> assertThat(savedPopup.getImageUrl()).isEqualTo("https://bucket/asdf"),
                     () ->
-                            assertThat(popup.getPopupStartDate())
+                            assertThat(savedPopup.getPopupStartDate())
                                     .isEqualTo(LocalDate.parse("2025-01-01")),
                     () ->
-                            assertThat(popup.getPopupEndDate())
+                            assertThat(savedPopup.getPopupEndDate())
                                     .isEqualTo(LocalDate.parse("2025-01-31")));
 
             List<Survey> surveyList = surveyRepository.findAll();
-            assertThat(surveyList).hasSize(4);
+            assertThat(surveyList).hasSize(4); // 기존 팝업 + 새로 생성된 팝업의 설문들
 
             List<Choice> choiceList = choiceRepository.findAll();
             assertThat(choiceList).hasSize(16);
@@ -89,21 +96,61 @@ public class PopupServiceTest extends IntegrationTest {
     class 팝업_목록_조회 {
         @Test
         @Transactional
-        void 팝업_목록_성공한다() {
+        void 팝업_목록_조회에_성공한다() {
             // given
-            PopupWithChoicesCreateRequest popupWithChoicesCreateRequest =
-                    createPopupWithChoicesCreateRequest();
-            popupService.createPopup(popupWithChoicesCreateRequest);
-            popupService.createPopup(popupWithChoicesCreateRequest);
+            createPopup();
+            createPopup();
 
             // when
             List<PopupPreviewResponse> popupPreviewResponseList = popupService.findAllPopups();
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(popupPreviewResponseList).hasSize(2),
-                    () -> assertThat(popupPreviewResponseList.get(0).popupId()).isEqualTo(2L),
-                    () -> assertThat(popupPreviewResponseList.get(1).popupId()).isEqualTo(1L));
+                    () -> assertThat(popupPreviewResponseList).hasSize(2), // 기존 팝업 + 새로 생성된 팝업
+                    () -> assertThat(popupPreviewResponseList.get(0).popupId()).isNotNull(),
+                    () -> assertThat(popupPreviewResponseList.get(1).popupId()).isNotNull());
+        }
+    }
+
+    @Nested
+    class 팝업_삭제 {
+        @Test
+        @Transactional
+        void 정상적으로_팝업을_삭제한다() {
+            // given
+            Long popupId = createPopup();
+
+            // when
+            popupService.deletePopup(popupId);
+
+            // then
+            assertThat(popupRepository.findById(popupId)).isEmpty();
+        }
+
+        @Test
+        @Transactional
+        void 존재하지_않는_팝업을_삭제하면_예외가_발생한다() {
+            // given
+            final Long nonExistentPopupId = 9999L;
+
+            // when & then
+            assertThatThrownBy(() -> popupService.deletePopup(nonExistentPopupId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
+        }
+
+        @Test
+        @Transactional
+        void 권한이_없는_사용자가_팝업을_삭제하면_예외가_발생한다() {
+            // given
+            final Long popupId = createPopup();
+
+            setAuthentication(otherManager);
+
+            // when & then
+            assertThatThrownBy(() -> popupService.deletePopup(popupId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
         }
     }
 
@@ -133,5 +180,10 @@ public class PopupServiceTest extends IntegrationTest {
                                 List.of("choice1", "choice2", "choice3", "choice4")),
                         new ChoiceCreateRequest(
                                 List.of("choice1", "choice2", "choice3", "choice4"))));
+    }
+
+    private Long createPopup() {
+        PopupCreateResponse popup = popupService.createPopup(createPopupWithChoicesCreateRequest());
+        return popup.popupId();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-127]

---
## 📌 작업 내용 및 특이사항

- 팝업 삭제 기능 구현했습니다.
- 기존 popup 테스트 코드에 setAuthentication 사용하도록 변경했습니다.

### 응답 예시
> 성공 시
```json
{
  "success": true,
  "status": 200,
  "data": null,
  "timestamp": "2025-05-12T19:07:07.608886"
}
```

> 실패 시
- 존재하지 않는 팝업에 대한 요청 (404)
```json
{
  "success": false,
  "status": 404,
  "data": {
    "errorClassName": "POPUP_NOT_FOUND",
    "message": "해당 팝업이 존재하지 않습니다."
  },
  "timestamp": "2025-05-13T00:24:27.682552"
}
```
- 팝업을 소유하지 않은 사용자의 요청 (403)
```json
{
  "success": false,
  "status": 403,
  "data": {
    "errorClassName": "POPUP_UNAUTHORIZED",
    "message": "해당 팝업의 소유자가 아닙니다."
  },
  "timestamp": "2025-05-13T00:25:53.726214"
}
```

---
## 📚 참고사항

-


[LCR-127]: https://lgcns-retail.atlassian.net/browse/LCR-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ