### PR TITLE
fix: EC2 배포 시 ECR 이미지 갱신이 적용되지 않는 문제 수정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -81,6 +81,7 @@ jobs:
           script: |
             aws ecr get-login-password --region ${{ env.AWS_REGION }} \
             | docker login --username AWS --password-stdin ${{ secrets.ECR_URI }}
+            docker compose pull
             docker compose up -d
             docker exec nginx nginx -s reload
             docker image prune -a -f


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-131]

---
## 📌 작업 내용 및 특이사항

- EC2에서 docker compose up만 수행되던 기존 워크플로우에서 ECR에 push된 최신 이미지가 반영되지 않는 문제가 있었습니다.
- 이를 해결하기 위해 docker compose pull 명령을 추가하여 배포 시 항상 최신 이미지를 가져오도록 수정했습니다.

[LCR-131]: https://lgcns-retail.atlassian.net/browse/LCR-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ