### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -4,4 +4,4 @@ services:
   redis:
     image: "redis:alpine"
     ports:
-      - "6379:6379"
+      - "7379:6379"

--- a/src/main/java/com/lgcns/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/lgcns/domain/manager/controller/ManagerController.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.manager.controller;
 
 import com.lgcns.domain.manager.dto.request.ManagerCreateRequest;
 import com.lgcns.domain.manager.service.ManagerService;
+import com.lgcns.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,11 +21,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class ManagerController {
 
     private final ManagerService managerService;
+    private final CookieUtil cookieUtil;
 
     @PostMapping
     @Operation(summary = "운영자 계정 생성", description = "운영자가 직접 요청하지 않고, 개발자가 생성 후 전달하는 내부용 API입니다.")
     public ResponseEntity<Void> managerCreate(@RequestBody @Valid ManagerCreateRequest request) {
         managerService.createManager(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "운영자 로그아웃", description = "운영자 로그아웃을 진행합니다.")
+    public ResponseEntity<Void> managerLogout() {
+        managerService.logoutManager();
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
     }
 }

--- a/src/main/java/com/lgcns/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/lgcns/domain/manager/service/ManagerService.java
@@ -4,4 +4,6 @@ import com.lgcns.domain.manager.dto.request.ManagerCreateRequest;
 
 public interface ManagerService {
     void createManager(ManagerCreateRequest request);
+
+    void logoutManager();
 }

--- a/src/main/java/com/lgcns/domain/manager/service/ManagerServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/manager/service/ManagerServiceImpl.java
@@ -1,10 +1,12 @@
 package com.lgcns.domain.manager.service;
 
+import com.lgcns.domain.auth.repository.RefreshTokenRepository;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.dto.request.ManagerCreateRequest;
 import com.lgcns.domain.manager.exception.ManagerErrorCode;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.global.error.exception.CustomException;
+import com.lgcns.global.util.ManagerUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,8 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class ManagerServiceImpl implements ManagerService {
+
     private final ManagerRepository managerRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ManagerUtil managerUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public void createManager(ManagerCreateRequest request) {
@@ -29,5 +34,14 @@ public class ManagerServiceImpl implements ManagerService {
         Manager manager = Manager.createManager(request.username(), encodedPassword);
 
         managerRepository.save(manager);
+    }
+
+    @Override
+    public void logoutManager() {
+        final Manager currentManager = managerUtil.getCurrentManager();
+
+        refreshTokenRepository
+                .findById(currentManager.getId())
+                .ifPresent(refreshTokenRepository::delete);
     }
 }

--- a/src/main/java/com/lgcns/global/util/CookieUtil.java
+++ b/src/main/java/com/lgcns/global/util/CookieUtil.java
@@ -32,6 +32,23 @@ public class CookieUtil {
         return headers;
     }
 
+    public HttpHeaders deleteRefreshTokenCookie() {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .domain(getCookieDomain())
+                        .secure(true)
+                        .sameSite(Cookie.SameSite.NONE.attributeValue())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
     private String getCookieDomain() {
         return switch (springEnvironmentHelper.getCurrentProfile()) {
             case DEV -> ".ceo.popi.today";

--- a/src/test/java/com/lgcns/domain/manager/service/ManagerServiceTest.java
+++ b/src/test/java/com/lgcns/domain/manager/service/ManagerServiceTest.java
@@ -4,14 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.lgcns.IntegrationTest;
+import com.lgcns.domain.auth.domain.RefreshToken;
+import com.lgcns.domain.auth.repository.RefreshTokenRepository;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.dto.request.ManagerCreateRequest;
 import com.lgcns.domain.manager.exception.ManagerErrorCode;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.global.error.exception.CustomException;
+import com.lgcns.global.security.PrincipalDetails;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +25,7 @@ class ManagerServiceTest extends IntegrationTest {
     @Autowired private ManagerRepository managerRepository;
     @Autowired private ManagerService managerService;
     @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private RefreshTokenRepository refreshTokenRepository;
 
     @Nested
     class 운영자_회원가입을_할_때 {
@@ -65,6 +72,36 @@ class ManagerServiceTest extends IntegrationTest {
             String encodedPassword = passwordEncoder.encode(plainPassword);
 
             return Manager.createManager(username, encodedPassword);
+        }
+    }
+
+    @Nested
+    class 운영자가_로그아웃을_할_때 {
+        @Test
+        void 로그아웃하면_리프레시_토큰이_삭제된다() {
+            // given
+            Manager manager =
+                    managerRepository.save(Manager.createManager("testUsername", "testPassword"));
+
+            UserDetails userDetails =
+                    new PrincipalDetails(manager.getId(), manager.getRole(), null);
+            UsernamePasswordAuthenticationToken token =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(token);
+
+            RefreshToken refreshToken =
+                    RefreshToken.builder()
+                            .managerId(manager.getId())
+                            .token("testRefreshToken")
+                            .build();
+            refreshTokenRepository.save(refreshToken);
+
+            // when
+            managerService.logoutManager();
+
+            // then
+            assertThat(refreshTokenRepository.findById(manager.getId())).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-122]

---
## 📌 작업 내용 및 특이사항

- 운영자 로그아웃 API를 구현하였습니다.
  - Redis에서 해당 운영자의 리프레시 토큰을 삭제합니다.
  - 브라우저에 저장된 리프레시 토큰 쿠키를 삭제하기 위해 Set-Cookie 헤더에 maxAge=0을 설정하였습니다.
- 쿠키의 도메인, Secure, SameSite, HttpOnly 설정은 기존과 동일하게 유지했습니다.

[LCR-122]: https://lgcns-retail.atlassian.net/browse/LCR-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ