### PR TITLE
feat: 팝업 및 상품 샘플 데이터 추가 및 팝업 목록 정렬 방식 변경

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -23,7 +23,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                                 PopupPreviewResponse.class, popup.id, popup.name, popup.imageUrl))
                 .from(popup)
                 .where(popup.manager.id.eq(managerId))
-                .orderBy(popup.id.desc())
+                .orderBy(popup.id.asc())
                 .fetch();
     }
 }

--- a/src/main/resources/db/migration/V10_3__update_popup_data.sql
+++ b/src/main/resources/db/migration/V10_3__update_popup_data.sql
@@ -1,0 +1,14 @@
+UPDATE popup
+SET image_url = 'https://visla.kr/wp/wp-content/uploads/2023/09/230913_00.jpg',
+    updated_at = NOW()
+WHERE popup_id = 1;
+
+UPDATE popup
+SET image_url = 'https://cdn.slist.kr/news/photo/202409/582734_918712_1713.jpeg',
+    updated_at = NOW()
+WHERE popup_id = 2;
+
+UPDATE popup
+SET image_url = 'https://atzip.kr/wp-content/uploads/2025/03/i_i_exh__2025-03-04T010004.000Z-optimized.jpg',
+    updated_at = NOW()
+WHERE popup_id = 3;

--- a/src/main/resources/db/migration/V10_4__update_item_data.sql
+++ b/src/main/resources/db/migration/V10_4__update_item_data.sql
@@ -1,0 +1,31 @@
+UPDATE item
+SET
+    name = "데이즈드 DAZED A형 (지수) : 1월 [2024]",
+    price = 15000,
+    image_url = 'https://ygselect.com/web/product/big/202402/P0000NMY.jpg',
+    updated_at = NOW()
+WHERE item_id = 1;
+
+UPDATE item
+SET
+    name = "DAZED C형 (로제) : 스프링 에디션 [2024]",
+    price = 15000,
+    image_url = 'https://ygselect.com/web/product/big/202404/257d66b0a1eca57af67b6c792e68ed75.jpg',
+    updated_at = NOW()
+WHERE item_id = 2;
+
+UPDATE item
+SET
+    name = "DAZED A형 (제니) : 홀리데이 에디션 [2021]",
+    price = 9500,
+    image_url = 'https://image.aladin.co.kr/product/28453/14/cover500/k572835617_1.jpg',
+    updated_at = NOW()
+WHERE item_id = 3;
+
+UPDATE item
+SET
+    name = "DAZED A형 (리사) : [2019]",
+    price = 8000,
+    image_url = 'https://image.aladin.co.kr/product/17920/59/cover500/k142534034_1.jpg',
+    updated_at = NOW()
+WHERE item_id = 4;

--- a/src/main/resources/db/migration/V10_5__insert_item_data.sql
+++ b/src/main/resources/db/migration/V10_5__insert_item_data.sql
@@ -1,0 +1,25 @@
+INSERT INTO item (item_id, popup_id, name, image_url, price, stock, min_stock, location, created_at, updated_at) VALUES
+(5, 1, '[BLACKPINK THE GAME PHOTOCARD COLLECTION] BACK TO RETRO', 'https://ygselect.com/web/product/big/202403/85207b44a40a4f3f29b5c991748491b3.jpg', 16500, 500, 10, 'c1', NOW(), NOW()),
+(6, 1, 'BLACKPINK THE GAME PHOTOCARD COLLECTION LOVELY VALENTINES EDITION', 'https://ygselect.com/web/product/big/202402/P0000NMT.jpg', 15000, 500, 10, 'c2', NOW(), NOW()),
+(7, 1, 'BLACKPINK THE GAME PHOTOCARD COLLECTION CHRISTMAS EDITION', 'https://ygselect.com/web/product/big/202402/P0000NJZ.jpg', 35000, 500, 10, 'c3', NOW(), NOW()),
+(8, 1, 'BLACKPINK THE GAME PHOTOCARD COLLECTION No.4~6 (SET)', 'https://ygselect.com/web/product/big/202402/P0000NGE.jpg', 88000, 500, 10, 'c4', NOW(), NOW()),
+
+(9, 1, '[EUP23] BLACKPINK COLLECTIBLE FIGURE_JISOO', 'https://m.ygselect.com/web/product/big/202110/51086d5fd28f00991986031b2ed3f742.jpg', 84000, 500, 10, 'b1', NOW(), NOW()),
+(10, 1, '[EUP23] BLACKPINK COLLECTIBLE FIGURE_ROSÉ', 'https://m.ygselect.com/web/product/big/202110/ce8b0e62d14355436540041d546aba6e.jpg', 84000, 500, 10, 'b2', NOW(), NOW()),
+(11, 1, '[EUP23] BLACKPINK COLLECTIBLE FIGURE_JENNIE', 'https://m.ygselect.com/web/product/big/202110/2a6e37d9264f4ce3219159a72f66e1d0.jpg', 84000, 500, 10, 'b3', NOW(), NOW()),
+(12, 1, '[EUP23] BLACKPINK COLLECTIBLE FIGURE_LISA', 'https://m.ygselect.com/web/product/big/202110/c2571baad5d4a020a02955b4350381de.jpg', 84000, 500, 10, 'b2', NOW(), NOW()),
+
+(13, 1, 'BLACKPINK POP-UP STORE POSTER SET', 'https://ygselect.com/web/product/big/202405/2d4917a57708caf6b1dc212cd91cf485.jpg', 15000, 500, 10, 'd1', NOW(), NOW()),
+(14, 1, '[BLACKPINK THE GAME] CONCERT STAND (LIMITED)', 'https://ygselect.com/web/product/big/202402/P0000NGG.jpg', 32500, 500, 10, 'd2', NOW(), NOW()),
+(15, 1, '블랙핑크 (BLACKPINK) - 블랙핑크 더 게임 OST [THE GIRLS] Stella ver. (LIMITED EDITION)', 'https://ygselect.com/web/product/big/202402/P0000MZH.jpg', 24000, 500, 10, 'd3', NOW(), NOW()),
+(16, 1, '[JZW] BLACKPINK BROKEN HEART SUPERSTARS', 'https://ygselect.com/web/product/big/202402/P0000ILJ.jpg', 17900, 500, 10, 'd4', NOW(), NOW()),
+
+(17, 1, '[INYOURAREA] KRUNK X BLACKPINK MINI CROSS BAG', 'https://ygselect.com/web/product/big/shop1_738be1088b092afab065be5299d5e2a4.png', 15000, 500, 10, 'e1', NOW(), NOW()),
+(18, 1, '[INYOURAREA] KRUNK X BLACKPINK MINI ROUND CROSS BAG', 'https://ygselect.com/web/product/big/shop1_cdf3bd187203a3987f4c262e73061334.png', 20000, 500, 10, 'e2', NOW(), NOW()),
+(19, 1, '[INYOURAREA] KRUNK X BLACKPINK ACTION BUNNY HAT', 'https://ygselect.com/web/product/extra/small/shop1_a715b60714bc92fe45c55be6d36a7add.png', 15000, 500, 10, 'e3', NOW(), NOW()),
+(20, 1, '[INYOURAREA] KRUNK X BLACKPINK HOODED CUSHION', 'https://ygselect.com/web/product/big/202403/P0000HDP.jpg', 25000, 500, 10, 'e4', NOW(), NOW()),
+
+(21, 1, '[INYOURAREA] KRUNK X BLACKPINK WRIST TOY_KRUNK', 'https://ygselect.com/web/product/big/202403/P0000HDL.jpg', 7000, 500, 10, 'f1', NOW(), NOW()),
+(22, 1, '[INYOURAREA] KRUNK X BLACKPINK KEYRING', 'https://ygselect.com/web/product/big/shop1_d2725a478a33ccaa10b1b7f8697f5c9d.png', 14000, 500, 10, 'f2', NOW(), NOW()),
+(23, 1, '[INYOURAREA] KRUNK X BLACKPINK MINI CUSHION (30CM)', 'https://ygselect.com/web/product/big/shop1_6e08c64b2daaf6f2142cbd32c9c7a38a.jpg', 18000, 500, 10, 'f3', NOW(), NOW()),
+(24, 1, '[INYOURAREA] KRUNK X BLACKPINK BIG CUSHION (45CM)', 'https://ygselect.com/web/product/big/shop1_c46529e55a48ad83a68b0f78540465e8.jpg', 25000, 500, 10, 'f4', NOW(), NOW());


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-143]

---
## 📌 작업 내용 및 특이사항

- 개발 환경에서 기획 검토 및 화면 구현 테스트를 위한 팝업/상품 샘플 데이터를 구성했습니다.
  - 매대(a1~f4) 단위로 상품 유형(잡지, 피규어, 포토카드, 굿즈 등)을 나눠 등록했습니다.
  - 총 24개의 아이템이 포함되며, stock은 500, min_stock은 10으로 일괄 설정하였습니다.
  - 잡지류(기존 item_id 1~4)는 UPDATE 방식으로 교체하였고, 나머지는 신규 INSERT 처리했습니다.

- 팝업 목록 조회 시 정렬 기준을 기존 `createdAt DESC` → `ASC`로 수정하였습니다.
  - UX 흐름상 오래된 팝업부터 확인하는 것이 자연스럽고 테스트 시에도 직관적인 확인이 가능하도록 변경했습니다.

- 아래의 Flyway 마이그레이션 파일을 통해 데이터가 반영됩니다:
  - `V10_3__update_popup_data.sql`: 팝업 이미지 데이터 수정
  - `V10_4__update_item_data.sql`: 기존 아이템 4건 정보 교체
  - `V10_5__insert_item_data.sql`: 신규 샘플 아이템 일괄 추가

---
## 📚 참고사항

- 아래 개발 클라이언트 도메인에서 manager1 id로 로그인하시면 샘플 데이터 확인하실 수 있습니다~
- https://www.dev.ceo.popi.today/items 


[LCR-143]: https://lgcns-retail.atlassian.net/browse/LCR-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ