### PR TITLE
fix: 1인 평균 구매액 API 응답 타입 변경 및 예약 분석 조회 API 엔드포인트 수정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
 
 env:
   AWS_REGION: ap-northeast-2

--- a/src/main/java/com/lgcns/domain/paymentStats/dto/response/PaymentAverageResponse.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/dto/response/PaymentAverageResponse.java
@@ -1,3 +1,3 @@
 package com.lgcns.domain.paymentStats.dto.response;
 
-public record PaymentAverageResponse(String totalPrice, String todayPrice) {}
+public record PaymentAverageResponse(Integer totalPrice, Integer todayPrice) {}

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
@@ -44,7 +44,7 @@ public class PaymentStatsRepositoryImpl implements PaymentStatsRepositoryCustom 
                         .fetchOne();
 
         return new PaymentAverageResponse(
-                String.valueOf(Math.round(totalAvg != null ? totalAvg : 0)),
-                String.valueOf(Math.round(todayAvg != null ? todayAvg : 0)));
+                (int) Math.round(totalAvg != null ? totalAvg : 0),
+                (int) Math.round(todayAvg != null ? todayAvg : 0));
     }
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/controller/ReservationStatsController.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/controller/ReservationStatsController.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/popup/{popupId}/dashboard/reservations")
+@RequestMapping("/popups/{popupId}/dashboard/reservations")
 @RequiredArgsConstructor
 @Tag(name = "9. 예약 분석 API", description = "예약 분석 관련 API 입니다.")
 public class ReservationStatsController {

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -191,8 +191,8 @@ class PaymentStatsServiceTest extends IntegrationTest {
             PaymentAverageResponse response = paymentStatsService.getPaymentAverages(popupId);
 
             // then
-            assertThat(response.totalPrice()).isEqualTo("5000"); // 5000
-            assertThat(response.todayPrice()).isEqualTo("6000"); // 6000
+            assertThat(response.totalPrice()).isEqualTo(5000);
+            assertThat(response.todayPrice()).isEqualTo(6000);
         }
 
         @Test
@@ -206,8 +206,8 @@ class PaymentStatsServiceTest extends IntegrationTest {
             PaymentAverageResponse response = paymentStatsService.getPaymentAverages(popupId);
 
             // then
-            assertThat(response.totalPrice()).isEqualTo("0");
-            assertThat(response.todayPrice()).isEqualTo("0");
+            assertThat(response.totalPrice()).isEqualTo(0);
+            assertThat(response.todayPrice()).isEqualTo(0);
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-147]

---
## 📌 작업 내용 및 특이사항

- 1인 평균 구매액 API의 응답 필드 타입을 `String → Integer`로 변경하였습니다.
  - 금액 데이터는 정수형이 보다 적절하다고 판단하여, totalPrice, todayPrice의 타입을 Integer로 수정하였습니다.
- 예약 분석 조회 API의 엔드포인트를 클라이언트 측 요청 경로와 일치하도록 수정했습니다.

[LCR-147]: https://lgcns-retail.atlassian.net/browse/LCR-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ