### PR TITLE
feat: 특정 상품에 대한 관심자 수 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
     implementation "org.apache.poi:poi:5.4.1"
     implementation "org.apache.poi:poi-ooxml:5.4.1"
 
+    // DynamoDB
+    implementation platform('software.amazon.awssdk:bom:2.28.11')
+    implementation 'software.amazon.awssdk:dynamodb-enhanced'
 }
 
 jar { enabled = true }

--- a/src/main/java/com/lgcns/domain/conversionStats/domain/ItemEvent.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/domain/ItemEvent.java
@@ -1,0 +1,31 @@
+package com.lgcns.domain.conversionStats.domain;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class ItemEvent {
+
+    private String popupId;
+    private Long itemId;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("popup_id")
+    public String getPopupId() {
+        return popupId;
+    }
+
+    public void setPopupId(String popupId) {
+        this.popupId = popupId;
+    }
+
+    @DynamoDbAttribute("item_id")
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/domain/PopupEvent.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/domain/PopupEvent.java
@@ -5,7 +5,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
 @DynamoDbBean
-public class ItemEvent {
+public class PopupEvent {
 
     private String popupId;
     private Long itemId;

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
@@ -2,7 +2,7 @@ package com.lgcns.domain.conversionStats.service;
 
 // import com.lgcns.domain.conversionStats.domain.Interest;
 
-import com.lgcns.domain.conversionStats.domain.ItemEvent;
+import com.lgcns.domain.conversionStats.domain.PopupEvent;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
@@ -37,9 +37,9 @@ public class ConversionStatsService {
 
         validatePopupOwnership(currentManager, popup);
 
-        DynamoDbTable<ItemEvent> table =
+        DynamoDbTable<PopupEvent> table =
                 dynamoDbEnhancedClient.table(
-                        dynamoDbProperties.tableName(), TableSchema.fromBean(ItemEvent.class));
+                        dynamoDbProperties.tableName(), TableSchema.fromBean(PopupEvent.class));
 
         QueryConditional condition =
                 QueryConditional.keyEqualTo(

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
@@ -1,0 +1,64 @@
+package com.lgcns.domain.conversionStats.service;
+
+// import com.lgcns.domain.conversionStats.domain.Interest;
+
+import com.lgcns.domain.conversionStats.domain.ItemEvent;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.popup.domain.Popup;
+import com.lgcns.domain.popup.exception.PopupErrorCode;
+import com.lgcns.domain.popup.repository.PopupRepository;
+import com.lgcns.global.error.exception.CustomException;
+import com.lgcns.global.util.ManagerUtil;
+import com.lgcns.infra.dynamodb.DynamoDbProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ConversionStatsService {
+
+    private final ManagerUtil managerUtil;
+    private final PopupRepository popupRepository;
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final DynamoDbProperties dynamoDbProperties;
+
+    private Long countInterestedUsersByItem(Long popupId, Long targetItemId) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+        final Popup popup = findPopupById(popupId);
+
+        validatePopupOwnership(currentManager, popup);
+
+        DynamoDbTable<ItemEvent> table =
+                dynamoDbEnhancedClient.table(
+                        dynamoDbProperties.tableName(), TableSchema.fromBean(ItemEvent.class));
+
+        QueryConditional condition =
+                QueryConditional.keyEqualTo(
+                        Key.builder().partitionValue(popupId.toString()).build());
+
+        return table.query(r -> r.queryConditional(condition)).items().stream()
+                .filter(i -> i.getItemId().equals(targetItemId))
+                .count();
+    }
+
+    private Popup findPopupById(Long popupId) {
+        return popupRepository
+                .findById(popupId)
+                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
+    }
+
+    private void validatePopupOwnership(Manager manager, Popup popup) {
+        if (!popup.getManager().equals(manager)) {
+            throw new CustomException(PopupErrorCode.POPUP_UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/lgcns/infra/aws/AwsProperties.java
+++ b/src/main/java/com/lgcns/infra/aws/AwsProperties.java
@@ -1,0 +1,6 @@
+package com.lgcns.infra.aws;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cloud.aws")
+public record AwsProperties(String region, String accessKey, String secretKey) {}

--- a/src/main/java/com/lgcns/infra/dynamodb/DynamoDbConfig.java
+++ b/src/main/java/com/lgcns/infra/dynamodb/DynamoDbConfig.java
@@ -1,0 +1,34 @@
+package com.lgcns.infra.dynamodb;
+
+import com.lgcns.infra.aws.AwsProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class DynamoDbConfig {
+
+    private final AwsProperties awsProperties;
+
+    @Bean
+    public DynamoDbClient dynamoDbClient() {
+        return DynamoDbClient.builder()
+                .region(Region.of(awsProperties.region()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        awsProperties.accessKey(), awsProperties.secretKey())))
+                .build();
+    }
+
+    @Bean
+    public DynamoDbEnhancedClient dynamoDbEnhancedClient(DynamoDbClient dynamoDbClient) {
+        return DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+    }
+}

--- a/src/main/java/com/lgcns/infra/dynamodb/DynamoDbProperties.java
+++ b/src/main/java/com/lgcns/infra/dynamodb/DynamoDbProperties.java
@@ -1,0 +1,6 @@
+package com.lgcns.infra.dynamodb;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("cloud.aws.dynamodb")
+public record DynamoDbProperties(String tableName) {}

--- a/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
+++ b/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
@@ -1,6 +1,7 @@
 package com.lgcns.infra.properties;
 
 import com.lgcns.infra.aws.AwsProperties;
+import com.lgcns.infra.dynamodb.DynamoDbProperties;
 import com.lgcns.infra.jwt.JwtProperties;
 import com.lgcns.infra.redis.RedisProperties;
 import com.lgcns.infra.s3.S3Properties;
@@ -11,7 +12,8 @@ import org.springframework.context.annotation.Configuration;
     RedisProperties.class,
     JwtProperties.class,
     AwsProperties.class,
-    S3Properties.class
+    S3Properties.class,
+    DynamoDbProperties.class
 })
 @Configuration
 public class PropertiesConfig {}

--- a/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
+++ b/src/main/java/com/lgcns/infra/properties/PropertiesConfig.java
@@ -1,11 +1,17 @@
 package com.lgcns.infra.properties;
 
+import com.lgcns.infra.aws.AwsProperties;
 import com.lgcns.infra.jwt.JwtProperties;
 import com.lgcns.infra.redis.RedisProperties;
 import com.lgcns.infra.s3.S3Properties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties({RedisProperties.class, JwtProperties.class, S3Properties.class})
+@EnableConfigurationProperties({
+    RedisProperties.class,
+    JwtProperties.class,
+    AwsProperties.class,
+    S3Properties.class
+})
 @Configuration
 public class PropertiesConfig {}

--- a/src/main/java/com/lgcns/infra/s3/S3Config.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Config.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.lgcns.infra.aws.AwsProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,15 +14,16 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class S3Config {
 
+    private final AwsProperties awsProperties;
     private final S3Properties s3Properties;
 
     @Bean
     public AmazonS3 s3Client() {
         BasicAWSCredentials credentials =
-                new BasicAWSCredentials(s3Properties.accessKey(), s3Properties.secretKey());
+                new BasicAWSCredentials(awsProperties.accessKey(), awsProperties.secretKey());
         AwsClientBuilder.EndpointConfiguration endpointConfiguration =
                 new AwsClientBuilder.EndpointConfiguration(
-                        s3Properties.endpoint(), s3Properties.region());
+                        s3Properties.endpoint(), awsProperties.region());
 
         return AmazonS3ClientBuilder.standard()
                 .withEndpointConfiguration(endpointConfiguration)

--- a/src/main/java/com/lgcns/infra/s3/S3Properties.java
+++ b/src/main/java/com/lgcns/infra/s3/S3Properties.java
@@ -2,6 +2,5 @@ package com.lgcns.infra.s3;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties("cloud.aws")
-public record S3Properties(
-        String region, String accessKey, String secretKey, String bucket, String endpoint) {}
+@ConfigurationProperties("cloud.aws.s3")
+public record S3Properties(String bucket, String endpoint) {}

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,11 +1,13 @@
 spring:
   config:
     activate:
-      on-profile: "s3"
+      on-profile: "aws"
 cloud:
   aws:
     region: ${AWS_REGION}
     accessKey: ${AWS_ACCESS_KEY}
     secretKey: ${AWS_SECRET_KEY}
-    bucket: ${AWS_BUCKET}
-    endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+
+    s3:
+      bucket: ${S3_BUCKET}
+      endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: "aws"
 cloud:
   aws:
-    region: ${AWS_REGION}
+    region: ${AWS_REGION:ap-northeast-2}
     accessKey: ${AWS_ACCESS_KEY}
     secretKey: ${AWS_SECRET_KEY}
 
@@ -13,4 +13,4 @@ cloud:
       endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
 
     dynamodb:
-      table-name: ${DYNAMODB_TABLE_NAME}
+      table-name: ${DYNAMODB_TABLE_NAME:popup_event}

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -11,3 +11,6 @@ cloud:
     s3:
       bucket: ${S3_BUCKET}
       endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
+
+    dynamodb:
+      table-name: ${DYNAMODB_TABLE_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     include:
       - redis
       - security
-      - s3
+      - aws
 
 spring-doc:
   default-consumes-media-type: application/json


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-154]

---
## 📌 작업 내용 및 특이사항

- DynamoDB 연동을 통해 관심자 수 조회 기능을 구현하였습니다.
  - popup_event 테이블에서 popup_id, item_id 기준으로 관심 데이터를 조회하고 카운팅합니다.
  - AWS SDK의 DynamoDbEnhancedClient를 사용해 직접 쿼리하며 조회 결과에서 item_id 조건으로 필터링하여 관심자 수를 계산합니다.
- popup_event는 사용자 관심, 체류, 구매 등 상품에 대한 행동 이벤트를 저장하는 테이블입니다.
  - Partition Key: popup_id
  - 주요 속성: popup_id, item_id
  - 사용 용도:
  - 관심자 수 조회
  - 구매 전환율 분석
- 이번 PR에서는 관심자 수 조회 기능만 우선 구현하였으며 구매전환율 분석 기능은 이후 PR에서 추가로 구현할 예정입니다.

---
## 📚 참고사항

- DynamoDbEnhancedClient는 런타임 리플렉션을 사용하지 않고 명시적으로 정의된 getter 메서드를 통해 매핑을 수행합니다. 따라서, Lombok으로 생성된 getter 메서드는 어노테이션(@DynamoDbPartitionKey, @DynamoDbAttribute 등)이 붙어 있지 않기 때문에 무시될 수 있습니다. 이로 인해 DynamoDB 매핑이 제대로 동작하지 않을 수 있으므로, 이번 PR에서는 Lombok을 사용하지 않고 getter/setter 메서드를 명시적으로 구현하였습니다.

[LCR-154]: https://lgcns-retail.atlassian.net/browse/LCR-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ