### PR TITLE
fix: S3 버킷 환경변수 기본값 명시하도록 수정

### DIFF
--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -9,7 +9,7 @@ cloud:
     secretKey: ${AWS_SECRET_KEY}
 
     s3:
-      bucket: ${S3_BUCKET}
+      bucket: ${S3_BUCKET:popi-image-bucket}
       endpoint: ${S3_ENDPOINT:https://s3.ap-northeast-2.amazonaws.com}
 
     dynamodb:


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-164]

---
## 📌 작업 내용 및 특이사항

- cloud.aws.s3.bucket에 기본값을 명시해, 일부 환경에서 Presigned URL 발급 후 이미지 업로드 실패 이슈를 해결했습니다.
- 기존에는 cloud.aws으로 설정할 경우 잘 동작했으나, cloud.aws.s3.bucket으로 변경하면서 환경변수 주입이 누락되는 사례가 발생했습니다.
- 명확한 원인은 추후 확인이 필요하지만, 기본값을 선언함으로써 오류 발생을 방지하도록 처리했습니다.

[LCR-164]: https://lgcns-retail.atlassian.net/browse/LCR-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ