### PR TITLE
feat: 팝업 리스트 조회 Internal API구현

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/dto/response/PopupInfoResponse.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/PopupInfoResponse.java
@@ -1,0 +1,30 @@
+package com.lgcns.domain.popup.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PopupInfoResponse(
+        @JsonProperty("popupId") @Schema(description = "팝업스토어 ID", example = "1") Long popupId,
+        @JsonProperty("popupName") @Schema(description = "팝업스토어 이름", example = "BLACKPINK 팝업스토어")
+                String popupName,
+        @JsonProperty("imageUrl")
+                @Schema(description = "팝업스토어 이미지 URL", example = "https://bucket/asdf")
+                String imageUrl,
+        @JsonProperty("popupOpenDate") @Schema(description = "팝업스토어 오픈 날짜", example = "2025-05-05")
+                String popupOpenDate,
+        @JsonProperty("popupCloseDate") @Schema(description = "팝업스토어 마감 날짜", example = "2025-06-06")
+                String popupCloseDate,
+        @JsonProperty("address")
+                @Schema(description = "팝업스토어 주소", example = "서울특별시 강남구 테헤란로 12, 1층 201호")
+                String address) {
+    public static PopupInfoResponse of(
+            Long popupId,
+            String popupName,
+            String imageUrl,
+            String popupOpenDate,
+            String popupCloseDate,
+            String address) {
+        return new PopupInfoResponse(
+                popupId, popupName, imageUrl, popupOpenDate, popupCloseDate, address);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/externalApi/PopupController.java
+++ b/src/main/java/com/lgcns/domain/popup/externalApi/PopupController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/popups")
 @RequiredArgsConstructor
-@Tag(name = "3. 팝업 API", description = "팝업 관련 API 입니다.")
+@Tag(name = "3-1. 팝업 API", description = "팝업 관련 API 입니다.")
 public class PopupController {
 
     private final PopupService popupService;

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -1,0 +1,34 @@
+package com.lgcns.domain.popup.internalApi;
+
+import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
+import com.lgcns.domain.popup.service.PopupService;
+import com.lgcns.global.common.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/popups")
+@RequiredArgsConstructor
+@Tag(name = "3-2. 팝업 Internal API", description = "팝업 관련 Internal API 입니다.")
+public class PopupInternalController {
+
+    private final PopupService popupService;
+
+    @GetMapping
+    @Operation(summary = "팝업 목록 조회", description = "현재 운영중인 모든 팝업 스토어 목록을 조회합니다.")
+    public SliceResponse<PopupInfoResponse> popupFindAll(
+            @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
+                    @RequestParam(required = false)
+                    Long lastPopupId,
+            @Parameter(description = "페이지 크기 (기본 8)", example = "8")
+                    @RequestParam(defaultValue = "8")
+                    int size) {
+        return popupService.findAllActivePopups(lastPopupId, size);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -1,9 +1,13 @@
 package com.lgcns.domain.popup.repository;
 
+import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import java.util.List;
+import org.springframework.data.domain.Slice;
 
 public interface PopupRepositoryCustom {
 
     List<PopupPreviewResponse> findAllPopupsByManagerId(Long managerId);
+
+    Slice<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -53,7 +53,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                         .from(popup)
                         .where(popup.popupEndDate.goe(LocalDate.now()), lastPopupId(lastPopupId))
                         .orderBy(popup.createdAt.desc())
-                        .limit(size + 1)
+                        .limit(size + 1L)
                         .fetch();
 
         return checkLastPage(size, results);

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -2,11 +2,17 @@ package com.lgcns.domain.popup.repository;
 
 import static com.lgcns.domain.popup.domain.QPopup.popup;
 
+import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,6 +20,7 @@ import org.springframework.stereotype.Repository;
 public class PopupRepositoryImpl implements PopupRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public List<PopupPreviewResponse> findAllPopupsByManagerId(Long managerId) {
@@ -25,5 +32,48 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .where(popup.manager.id.eq(managerId))
                 .orderBy(popup.id.asc())
                 .fetch();
+    }
+
+    @Override
+    public Slice<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size) {
+        List<PopupInfoResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        PopupInfoResponse.class,
+                                        popup.id,
+                                        popup.name,
+                                        popup.imageUrl,
+                                        popup.popupStartDate.stringValue(),
+                                        popup.popupEndDate.stringValue(),
+                                        popup.address
+                                                .roadAddress
+                                                .concat(", ")
+                                                .concat(popup.address.detailAddress)))
+                        .from(popup)
+                        .where(popup.popupEndDate.goe(LocalDate.now()), lastPopupId(lastPopupId))
+                        .orderBy(popup.createdAt.desc())
+                        .limit(size + 1)
+                        .fetch();
+
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastPopupId(Long popupId) {
+        if (popupId == null) {
+            return null;
+        }
+        return popup.id.gt(popupId);
+    }
+
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
     }
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -2,7 +2,9 @@ package com.lgcns.domain.popup.service;
 
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
+import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.global.common.response.SliceResponse;
 import java.util.List;
 
 public interface PopupService {
@@ -11,4 +13,6 @@ public interface PopupService {
     List<PopupPreviewResponse> findAllPopups();
 
     void deletePopup(Long popupId);
+
+    SliceResponse<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -5,6 +5,7 @@ import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
+import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
@@ -15,6 +16,7 @@ import com.lgcns.domain.survey.domain.Survey;
 import com.lgcns.domain.survey.dto.request.ChoiceCreateRequest;
 import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
+import com.lgcns.global.common.response.SliceResponse;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import java.time.Duration;
@@ -25,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,6 +78,13 @@ public class PopupServiceImpl implements PopupService {
         validatePopupOwnership(currentManager, popup);
 
         popupRepository.delete(popup);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SliceResponse<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size) {
+        Slice<PopupInfoResponse> slice = popupRepository.findAllActivePopups(lastPopupId, size);
+        return SliceResponse.from(slice);
     }
 
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {

--- a/src/main/java/com/lgcns/global/common/response/SliceResponse.java
+++ b/src/main/java/com/lgcns/global/common/response/SliceResponse.java
@@ -1,0 +1,10 @@
+package com.lgcns.global.common.response;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(List<T> content, boolean isLast) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(slice.getContent(), slice.isLast());
+    }
+}

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -66,6 +66,8 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/reservations/**")
                                 .permitAll()
+                                .requestMatchers("/internal/**")
+                                .permitAll()
                                 .anyRequest()
                                 .authenticated());
 

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -64,8 +64,6 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/entrances")
                                 .permitAll()
-                                .requestMatchers("/reservations/**")
-                                .permitAll()
                                 .requestMatchers("/internal/**")
                                 .permitAll()
                                 .anyRequest()

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -10,6 +10,7 @@ import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
+import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
@@ -20,6 +21,7 @@ import com.lgcns.domain.survey.domain.Survey;
 import com.lgcns.domain.survey.dto.request.ChoiceCreateRequest;
 import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
+import com.lgcns.global.common.response.SliceResponse;
 import com.lgcns.global.error.exception.CustomException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -149,6 +151,153 @@ public class PopupServiceTest extends IntegrationTest {
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
         }
+    }
+
+    @Nested
+    class 운영중인_팝업_리스트_조회_openfeign {
+        @Test
+        @Transactional
+        void 운영중인_팝업의_리스트를_반환한다() {
+            LocalDate now = LocalDate.now();
+
+            Long activePopup1 = createPopupWithDates("운영중인팝업1", now.minusDays(5), now.plusDays(10));
+            Long activePopup2 = createPopupWithDates("운영중인팝업2", now.minusDays(1), now.plusDays(5));
+            Long activePopup3 = createPopupWithDates("운영중인팝업3", now, now.plusDays(15));
+
+            createPopupWithDates("종료된팝업1", now.minusDays(20), now.minusDays(1));
+
+            Long activePopup4 = createPopupWithDates("예정팝업1", now.plusDays(10), now.plusDays(20));
+
+            // when
+            SliceResponse<PopupInfoResponse> response = popupService.findAllActivePopups(null, 10);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content()).hasSize(4),
+                    () ->
+                            assertThat(response.content())
+                                    .extracting("popupId")
+                                    .containsExactlyInAnyOrder(
+                                            activePopup1, activePopup2, activePopup3, activePopup4),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        @Transactional
+        void 운영중인_팝업이_없으면_빈_리스트를_반환한다() {
+            // given
+            LocalDate now = LocalDate.now();
+
+            // 운영 종료된 팝업들만 생성
+            createPopupWithDates("종료된팝업1", now.minusDays(30), now.minusDays(10));
+            createPopupWithDates("종료된팝업2", now.minusDays(20), now.minusDays(5));
+
+            // when
+            SliceResponse<PopupInfoResponse> response = popupService.findAllActivePopups(null, 10);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content()).isEmpty(),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        @Transactional
+        void 페이징_처리가_정상적으로_동작한다() {
+            // given
+            LocalDate now = LocalDate.now();
+
+            // 운영중인 팝업 5개 생성
+            for (int i = 1; i <= 5; i++) {
+                createPopupWithDates("운영중인팝업" + i, now.minusDays(1), now.plusDays(10));
+            }
+
+            // when - 첫 번째 페이지 (size=3)
+            SliceResponse<PopupInfoResponse> firstPage = popupService.findAllActivePopups(null, 3);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(firstPage.content()).hasSize(3),
+                    () -> assertThat(firstPage.isLast()).isFalse());
+
+            // when - 두 번째 페이지
+            Long lastPopupId = firstPage.content().get(firstPage.content().size() - 1).popupId();
+            SliceResponse<PopupInfoResponse> secondPage =
+                    popupService.findAllActivePopups(lastPopupId, 3);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(secondPage.content()).hasSize(2),
+                    () -> assertThat(secondPage.isLast()).isTrue());
+        }
+    }
+
+    private Long createPopupWithAllParams(
+            String name,
+            String imageUrl,
+            LocalDate popupStartDate,
+            LocalDate popupEndDate,
+            LocalDateTime reservationOpenDateTime,
+            LocalDateTime reservationCloseDateTime,
+            LocalTime runOpenTime,
+            LocalTime runCloseTime,
+            int totalCapacity,
+            int timeCapacity,
+            String roadAddress,
+            String detailAddress,
+            Double latitude,
+            Double longitude,
+            List<ChoiceCreateRequest> choices) {
+
+        PopupCreateRequest popupCreateRequest =
+                new PopupCreateRequest(
+                        name,
+                        imageUrl,
+                        popupStartDate,
+                        popupEndDate,
+                        reservationOpenDateTime,
+                        reservationCloseDateTime,
+                        runOpenTime,
+                        runCloseTime,
+                        totalCapacity,
+                        timeCapacity,
+                        roadAddress,
+                        detailAddress,
+                        latitude,
+                        longitude);
+
+        PopupWithChoicesCreateRequest request =
+                new PopupWithChoicesCreateRequest(popupCreateRequest, choices);
+
+        PopupCreateResponse response = popupService.createPopup(request);
+        return response.popupId();
+    }
+
+    private Long createPopupWithDates(String name, LocalDate startDate, LocalDate endDate) {
+        return createPopupWithAllParams(
+                name,
+                "https://bucket/image.jpg",
+                startDate,
+                endDate,
+                LocalDateTime.of(startDate, LocalTime.of(10, 0)),
+                LocalDateTime.of(endDate, LocalTime.of(20, 0)),
+                LocalTime.of(10, 0),
+                LocalTime.of(20, 0),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456,
+                createDefaultChoices());
+    }
+
+    private List<ChoiceCreateRequest> createDefaultChoices() {
+        return List.of(
+                new ChoiceCreateRequest(List.of("choice1", "choice2", "choice3", "choice4")),
+                new ChoiceCreateRequest(List.of("choice1", "choice2", "choice3", "choice4")),
+                new ChoiceCreateRequest(List.of("choice1", "choice2", "choice3", "choice4")),
+                new ChoiceCreateRequest(List.of("choice1", "choice2", "choice3", "choice4")));
     }
 
     private PopupWithChoicesCreateRequest createPopupWithChoicesCreateRequest() {


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-193]

---
## 📌 작업 내용 및 특이사항

- user-server의 popup-service가 요청한 예약 가능한 팝업 리스트 조회 내부 API 구현했습니다.
- internalApi 디렉토리를 생성하고 하위에 PopupInternalController를 구현했습니다.
- 무한 스크롤 처리를 위한 Slice<T> 타입을 반환하기 위해 래핑하는 SliceResponse<T> DTO를 global/ 에 구현했습니다.
- 서비스 흐름 상 검증 로직과 예외 케이스가 존재하지 않으므로 Serivce에서는 단순히 호출만 하도록 구현했습니다.


[LCR-193]: https://lgcns-retail.atlassian.net/browse/LCR-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ