### PR TITLE
feat: 유저 서비스 상품 검색 API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -4,6 +4,7 @@ import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.service.ItemService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,11 +18,23 @@ public class ItemInternalController {
     private final ItemService itemService;
 
     @GetMapping
-    @Operation(summary = "상품 목록 조회", description = "현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.")
+    @Operation(
+            summary = "상품 목록 조회",
+            description =
+                    "searchName을 포함하지 않으면 현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.</br>"
+                            + "searchName을 포함하여 호출하면 상품명에 searchName이 포함된 모든 상품을 페이징 처리한 뒤 반환합니다.")
     public SliceResponse<ItemInfoResponse> userItemFindAll(
-            @PathVariable(name = "popupId") Long popupId,
-            @RequestParam(name = "lastItemId", required = false) Long lastItemId,
-            @RequestParam(name = "size", defaultValue = "8") int size) {
-        return itemService.findAllItemsByPagination(popupId, lastItemId, size);
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId,
+            @Parameter(description = "검색할 상품 이름 (비워두면 모든 상품을 반환합니다.)", example = "블랙핑크")
+                    @RequestParam(name = "searchName", required = false)
+                    String searchName,
+            @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
+                    @RequestParam(name = "lastItemId", required = false)
+                    Long lastItemId,
+            @Parameter(description = "페이지 크기 (기본 8)", example = "8")
+                    @RequestParam(name = "size", defaultValue = "8")
+                    int size) {
+        return itemService.findItemsByNameWithPagination(popupId, searchName, lastItemId, size);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
@@ -8,5 +8,6 @@ import org.springframework.data.domain.Slice;
 public interface ItemRepositoryCustom {
     List<ItemLocationResponse> findItemsWithSplitLocation(Long popupId);
 
-    Slice<ItemInfoResponse> findItemsWithPagination(Long popupId, Long lastItemId, int size);
+    Slice<ItemInfoResponse> findItemsByNameWithPagination(
+            Long popupId, String searchName, Long lastItemId, int size);
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
@@ -47,8 +47,8 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
     }
 
     @Override
-    public Slice<ItemInfoResponse> findItemsWithPagination(
-            Long popupId, Long lastItemId, int size) {
+    public Slice<ItemInfoResponse> findItemsByNameWithPagination(
+            Long popupId, String searchName, Long lastItemId, int size) {
         List<ItemInfoResponse> responses =
                 queryFactory
                         .select(
@@ -59,12 +59,19 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
                                         item.imageUrl,
                                         item.price))
                         .from(item)
-                        .where(item.popup.id.eq(popupId), lastItemCondition(lastItemId))
+                        .where(
+                                checkItemSearchName(searchName),
+                                item.popup.id.eq(popupId),
+                                lastItemCondition(lastItemId))
                         .orderBy(item.id.desc())
                         .limit(size + 1L)
                         .fetch();
 
         return checkLastPage(size, responses);
+    }
+
+    private BooleanExpression checkItemSearchName(String searchName) {
+        return searchName == null || searchName.isEmpty() ? null : item.name.contains(searchName);
     }
 
     private BooleanExpression lastItemCondition(Long itemId) {

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
@@ -71,11 +72,11 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
     }
 
     private BooleanExpression checkItemSearchName(String searchName) {
-        return searchName == null || searchName.isEmpty() ? null : item.name.contains(searchName);
+        return StringUtils.hasText(searchName) ? item.name.contains(searchName) : null;
     }
 
     private BooleanExpression lastItemCondition(Long itemId) {
-        return (itemId == null) ? null : item.id.lt(itemId);
+        return (itemId != null) ? item.id.lt(itemId) : null;
     }
 
     private Slice<ItemInfoResponse> checkLastPage(int pageSize, List<ItemInfoResponse> results) {

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -26,6 +26,6 @@ public interface ItemService {
     ItemDetailResponse updateItemMinStock(
             Long popupId, Long itemId, ItemMinStockUpdateRequest request);
 
-    SliceResponse<ItemInfoResponse> findAllItemsByPagination(
-            Long popupId, Long lastItemId, int size);
+    SliceResponse<ItemInfoResponse> findItemsByNameWithPagination(
+            Long popupId, String searchName, Long lastItemId, int size);
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -143,10 +143,10 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<ItemInfoResponse> findAllItemsByPagination(
-            Long popupId, Long lastItemId, int size) {
+    public SliceResponse<ItemInfoResponse> findItemsByNameWithPagination(
+            Long popupId, String searchName, Long lastItemId, int size) {
         Slice<ItemInfoResponse> itemInfoResponses =
-                itemRepository.findItemsWithPagination(popupId, lastItemId, size);
+                itemRepository.findItemsByNameWithPagination(popupId, searchName, lastItemId, size);
 
         return SliceResponse.from(itemInfoResponses);
     }

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -576,10 +576,10 @@ class ItemServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 내부용_상품_목록_조회 {
+    class 내부용_상품_목록을_조회할_때 {
         @Test
         @Transactional
-        void 내부용_상품_목록_조회에_성공한다() {
+        void 데이터가_존재하면_상품_목록_조회에_성공한다() {
             // given
             final Long popupId = popup.getId();
 
@@ -651,7 +651,7 @@ class ItemServiceTest extends IntegrationTest {
 
         @Test
         @Transactional
-        void 내부용_상품_검색에_성공한다() {
+        void 검색어에_대해_결과가_존재하면_상품_검색에_성공한다() {
             // given
             final Long popupId = popup.getId();
 
@@ -689,7 +689,7 @@ class ItemServiceTest extends IntegrationTest {
 
         @Test
         @Transactional
-        void 내부용_상품_검색_결과가_없으면_빈_리스트를_반환한다() {
+        void 검색어에_대해_결과가_없으면_빈_리스트를_반환한다() {
             // given
             final Long popupId = popup.getId();
 

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -599,7 +599,7 @@ class ItemServiceTest extends IntegrationTest {
 
             // when
             SliceResponse<ItemInfoResponse> result =
-                    itemService.findAllItemsByPagination(popupId, 4L, 2);
+                    itemService.findItemsByNameWithPagination(popupId, null, 4L, 2);
 
             // then
             Assertions.assertAll(
@@ -637,7 +637,7 @@ class ItemServiceTest extends IntegrationTest {
 
             // when
             SliceResponse<ItemInfoResponse> result =
-                    itemService.findAllItemsByPagination(popupId, 4L, 3);
+                    itemService.findItemsByNameWithPagination(popupId, null, 4L, 3);
 
             // then
             Assertions.assertAll(
@@ -647,6 +647,67 @@ class ItemServiceTest extends IntegrationTest {
                                     .hasSize(3), // lastItemId = 4 기준으로 id < 4 인 세 개만 조회된다고 가정
                     () -> assertThat(result.isLast()).isTrue() // isLast=true 검증
                     );
+        }
+
+        @Test
+        @Transactional
+        void 내부용_상품_검색에_성공한다() {
+            // given
+            final Long popupId = popup.getId();
+
+            Item item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+            Item item2 =
+                    Item.createItem(
+                            popup, "제니 포토카드", "https://bucket/jennie.jpg", 15000, 100, 10, "a2");
+            Item item3 =
+                    Item.createItem(
+                            popup, "로제 포토카드", "https://bucket/rose.jpg", 15000, 100, 10, "b1");
+
+            itemRepository.save(item1);
+            itemRepository.save(item2);
+            itemRepository.save(item3);
+
+            // when
+            SliceResponse<ItemInfoResponse> result =
+                    itemService.findItemsByNameWithPagination(popupId, "포토카드", 4L, 3);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).hasSize(3),
+                    () -> assertThat(result.isLast()).isTrue(),
+                    () ->
+                            assertThat(result.content())
+                                    .allSatisfy(
+                                            item ->
+                                                    assertThat(item.name())
+                                                            .contains("포토카드")) // 검색 결과 검증
+                    );
+        }
+
+        @Test
+        @Transactional
+        void 내부용_상품_검색_결과가_없으면_빈_리스트를_반환한다() {
+            // given
+            final Long popupId = popup.getId();
+
+            Item item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+
+            itemRepository.save(item1);
+
+            // when
+            SliceResponse<ItemInfoResponse> result =
+                    itemService.findItemsByNameWithPagination(popupId, "키링", null, 3);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.content()).isEmpty(), // 빈 리스트 검증
+                    () -> assertThat(result.isLast()).isTrue());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-210]

---
## 📌 작업 내용 및 특이사항

- 내부용 상품 검색 API를 구현하였습니다.
- 기존 전체 상품 조회 API와 통합하였으며, searchName의 포함 여부에 따라 전체 조회 또는 검색이 가능합니다.
- 상품 검색에 성공한 경우, 검색 결과가 없는 경우에 대해 테스트 코드를 작성하였으며, 별도의 예외 처리는 서비스 로직 흐름 상 추가하지 않았습니다.

---
## 📚 참고사항

-


[LCR-210]: https://lgcns-retail.atlassian.net/browse/LCR-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ