### PR TITLE
feat: 설문지 조회 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/dto/response/ChoiceInfoResponse.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/ChoiceInfoResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.popup.dto.response;
+
+public record ChoiceInfoResponse(Long surveyId, Long choiceId, String content) {
+    public static ChoiceInfoResponse of(Long surveyId, Long choiceId, String content) {
+        return new ChoiceInfoResponse(surveyId, choiceId, content);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/dto/response/SurveyChoiceResponse.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/SurveyChoiceResponse.java
@@ -1,0 +1,13 @@
+package com.lgcns.domain.popup.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record SurveyChoiceResponse(
+        @Schema(description = "DB에 등록된 설문지 번호", example = "2") Long surveyId,
+        @Schema(description = "선지 번호 및 내용", implementation = SurveyOption.class)
+                List<SurveyOption> options) {
+    public static SurveyChoiceResponse of(Long surveyId, List<SurveyOption> options) {
+        return new SurveyChoiceResponse(surveyId, options);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/dto/response/SurveyOption.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/SurveyOption.java
@@ -1,0 +1,11 @@
+package com.lgcns.domain.popup.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SurveyOption(
+        @Schema(description = "선지 번호", example = "1") Long choiceId,
+        @Schema(description = "선지 내용", example = "포스터") String content) {
+    public static SurveyOption of(Long choiceId, String content) {
+        return new SurveyOption(choiceId, content);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -1,26 +1,25 @@
 package com.lgcns.domain.popup.internalApi;
 
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
+import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
 import com.lgcns.domain.popup.service.PopupService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/internal/popups")
+@RequestMapping("/internal")
 @RequiredArgsConstructor
 @Tag(name = "3-2. 팝업 Internal API", description = "팝업 관련 Internal API 입니다.")
 public class PopupInternalController {
 
     private final PopupService popupService;
 
-    @GetMapping
+    @GetMapping("/popups")
     @Operation(summary = "팝업 목록 조회", description = "현재 운영중인 모든 팝업 스토어 목록을 조회합니다.")
     public SliceResponse<PopupInfoResponse> popupFindAll(
             @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
@@ -30,5 +29,11 @@ public class PopupInternalController {
                     @RequestParam(defaultValue = "8")
                     int size) {
         return popupService.findAllActivePopups(lastPopupId, size);
+    }
+
+    @GetMapping("/reservations/popups/{popupId}/survey")
+    @Operation(summary = "팝업에 등록된 설문지 목록 조회", description = "팝업 ID를 통해 등록된 설문지 목록을 조회합니다.")
+    public List<SurveyChoiceResponse> choiceListByPopupIdFind(@PathVariable Long popupId) {
+        return popupService.findAllChoicesByPopupId(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.lgcns.domain.popup.repository;
 
-import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
-import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.dto.response.*;
 import java.util.List;
 import org.springframework.data.domain.Slice;
 
@@ -10,4 +9,6 @@ public interface PopupRepositoryCustom {
     List<PopupPreviewResponse> findAllPopupsByManagerId(Long managerId);
 
     Slice<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size);
+
+    List<ChoiceInfoResponse> findAllChoices(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.lgcns.domain.popup.repository;
 
 import static com.lgcns.domain.popup.domain.QPopup.popup;
+import static com.lgcns.domain.survey.domain.QChoice.choice;
+import static com.lgcns.domain.survey.domain.QSurvey.survey;
 
+import com.lgcns.domain.popup.dto.response.ChoiceInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import com.querydsl.core.types.Projections;
@@ -57,6 +60,20 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                         .fetch();
 
         return checkLastPage(size, results);
+    }
+
+    @Override
+    public List<ChoiceInfoResponse> findAllChoices(Long popupId) {
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ChoiceInfoResponse.class, survey.id, choice.id, choice.content))
+                .from(popup)
+                .join(popup.surveyList, survey)
+                .join(survey.choiceList, choice)
+                .where(popup.id.eq(popupId))
+                .orderBy(survey.id.asc(), choice.number.asc())
+                .fetch();
     }
 
     private BooleanExpression lastPopupId(Long popupId) {

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -4,6 +4,7 @@ import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
 import com.lgcns.global.common.response.SliceResponse;
 import java.util.List;
 
@@ -15,4 +16,6 @@ public interface PopupService {
     void deletePopup(Long popupId);
 
     SliceResponse<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size);
+
+    List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -1,12 +1,12 @@
 package com.lgcns.domain.popup.service;
 
+import static java.util.stream.Collectors.toList;
+
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
-import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
-import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
-import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.dto.response.*;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.reservation.domain.Reservation;
@@ -25,6 +25,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Slice;
@@ -85,6 +87,28 @@ public class PopupServiceImpl implements PopupService {
     public SliceResponse<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size) {
         Slice<PopupInfoResponse> slice = popupRepository.findAllActivePopups(lastPopupId, size);
         return SliceResponse.from(slice);
+    }
+
+    @Override
+    public List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId) {
+
+        List<ChoiceInfoResponse> choiceInfoList = popupRepository.findAllChoices(popupId);
+
+        Map<Long, List<SurveyOption>> choices =
+                choiceInfoList.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        ChoiceInfoResponse::surveyId,
+                                        Collectors.mapping(
+                                                choiceInfo ->
+                                                        SurveyOption.of(
+                                                                choiceInfo.choiceId(),
+                                                                choiceInfo.content()),
+                                                toList())));
+
+        return choices.entrySet().stream()
+                .map(choice -> SurveyChoiceResponse.of(choice.getKey(), choice.getValue()))
+                .collect(Collectors.toList());
     }
 
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -12,6 +12,7 @@ import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.reservation.domain.Reservation;
@@ -229,6 +230,28 @@ public class PopupServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(secondPage.content()).hasSize(2),
                     () -> assertThat(secondPage.isLast()).isTrue());
+        }
+    }
+
+    @Nested
+    class 팝업_설문지_조회할_때 {
+
+        @Test
+        @Transactional
+        void 팝업_ID를_통해_설문지와_선지_조회에_성공한다() {
+            // given
+            Long popupId = createPopup();
+
+            // when
+            List<SurveyChoiceResponse> surveyChoices =
+                    popupService.findAllChoicesByPopupId(popupId);
+
+            // then
+            assertThat(surveyChoices).hasSize(4);
+            for (SurveyChoiceResponse choice : surveyChoices) {
+                assertThat(choice.surveyId()).isNotNull();
+                assertThat(choice.options()).hasSize(4);
+            }
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-203]

---
## 📌 작업 내용 및 특이사항

- User Service에서 사용되는 설문지 조회 기능을 구현했습니다.
- 도메인 책임 분리와 쿼리 효율성(중복 조회 방지)을 고려하여 Popup 도메인에서 일괄 조회하는 방식으로 구현했습니다.
- 기존 PopupInternalController의 @RequestMapping("/internal/popups")를 /internal로 수정했습니다.
- 서비스 시나리오를 생각했을 때, popupId를 통해 설문지를 조회할 때 예외 케이스는 없다고 판단하여 테스트 코드는 작성하지 않았습니다. 

---
## 📚 참고사항

- 하위 도메인(survey, choice)의 데이터 흐름을 상위 도메인(Popup) 기준으로 정리함으로써 도메인 간 책임을 명확히 분리했습니다. 향후 survey 또는 choice 관련 기능이 추가되더라도 Popup 도메인에서 조회를 시작하는 흐름은 그대로 유지될 수 있습니다.
- 응답 구조를 수정했습니다. 자세한 사항은 [링크](https://www.notion.so/API-1e1483a29ee480949f5be94fd080e72b?p=1f8483a29ee4809e8541de8c24b6148f&pm=s) 참고하시면 됩니다.


[LCR-203]: https://lgcns-retail.atlassian.net/browse/LCR-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ