### PR TITLE
feat: 유저 서비스 팝업 검색 API 엔드포인트 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -20,15 +20,22 @@ public class PopupInternalController {
     private final PopupService popupService;
 
     @GetMapping("/popups")
-    @Operation(summary = "팝업 목록 조회", description = "현재 운영중인 모든 팝업 스토어 목록을 조회합니다.")
+    @Operation(
+            summary = "팝업 목록 조회",
+            description =
+                    "searchName을 포함하지 않으면 현재 예약가능한 모든 팝업을 무한 스크롤을 위한 페이징 처리한 뒤 반환합니다.</br>"
+                            + "searchName을 포함하여 호출하면 팝업명에 searchName이 포함된 모든 팝업을 페이징 처리한 뒤 반환합니다.")
     public SliceResponse<PopupInfoResponse> popupFindAll(
+            @Parameter(description = "검색할 팝업 이름 (비워두면 모든 팝업을 반환합니다.)", example = "블랙핑크")
+                    @RequestParam(required = false)
+                    String searchName,
             @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
                     @RequestParam(required = false)
                     Long lastPopupId,
             @Parameter(description = "페이지 크기 (기본 8)", example = "8")
                     @RequestParam(defaultValue = "8")
                     int size) {
-        return popupService.findAllActivePopups(lastPopupId, size);
+        return popupService.findPopupsByNameWithPagination(searchName, lastPopupId, size);
     }
 
     @GetMapping("/reservations/popups/{popupId}/survey")

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -8,7 +8,7 @@ public interface PopupRepositoryCustom {
 
     List<PopupPreviewResponse> findAllPopupsByManagerId(Long managerId);
 
-    Slice<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size);
-
     List<ChoiceInfoResponse> findAllChoices(Long popupId);
+
+    Slice<PopupInfoResponse> findPopupsByNameWithPagination(String searchName, Long lastPopupId, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -10,5 +10,6 @@ public interface PopupRepositoryCustom {
 
     List<ChoiceInfoResponse> findAllChoices(Long popupId);
 
-    Slice<PopupInfoResponse> findPopupsByNameWithPagination(String searchName, Long lastPopupId, int size);
+    Slice<PopupInfoResponse> findPopupsByNameWithPagination(
+            String searchName, Long lastPopupId, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
@@ -38,7 +39,8 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
     }
 
     @Override
-    public Slice<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size) {
+    public Slice<PopupInfoResponse> findPopupsByNameWithPagination(
+            String searchName, Long lastPopupId, int size) {
         List<PopupInfoResponse> results =
                 jpaQueryFactory
                         .select(
@@ -54,7 +56,10 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                                                 .concat(", ")
                                                 .concat(popup.address.detailAddress)))
                         .from(popup)
-                        .where(popup.popupEndDate.goe(LocalDate.now()), lastPopupId(lastPopupId))
+                        .where(
+                                popup.popupEndDate.goe(LocalDate.now()),
+                                checkPopupSearchName(searchName),
+                                lastPopupCondition(lastPopupId))
                         .orderBy(popup.createdAt.desc())
                         .limit(size + 1L)
                         .fetch();
@@ -76,11 +81,12 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .fetch();
     }
 
-    private BooleanExpression lastPopupId(Long popupId) {
-        if (popupId == null) {
-            return null;
-        }
-        return popup.id.gt(popupId);
+    private BooleanExpression checkPopupSearchName(String searchName) {
+        return StringUtils.hasText(searchName) ? popup.name.contains(searchName) : null;
+    }
+
+    private BooleanExpression lastPopupCondition(Long popupId) {
+        return (popupId != null) ? popup.id.gt(popupId) : null;
     }
 
     private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -82,7 +82,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
     }
 
     private BooleanExpression checkPopupSearchName(String searchName) {
-        return StringUtils.hasText(searchName) ? popup.name.contains(searchName) : null;
+        return StringUtils.hasText(searchName) ? popup.name.contains(searchName.trim()) : null;
     }
 
     private BooleanExpression lastPopupCondition(Long popupId) {

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -17,5 +17,6 @@ public interface PopupService {
 
     List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId);
 
-    SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(String searchName, Long lastPopupId, int size);
+    SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(
+            String searchName, Long lastPopupId, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -15,7 +15,7 @@ public interface PopupService {
 
     void deletePopup(Long popupId);
 
-    SliceResponse<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size);
-
     List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId);
+
+    SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(String searchName, Long lastPopupId, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -84,8 +84,10 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     @Transactional(readOnly = true)
-    public SliceResponse<PopupInfoResponse> findAllActivePopups(Long lastPopupId, int size) {
-        Slice<PopupInfoResponse> slice = popupRepository.findAllActivePopups(lastPopupId, size);
+    public SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(
+            String searchName, Long lastPopupId, int size) {
+        Slice<PopupInfoResponse> slice =
+                popupRepository.findPopupsByNameWithPagination(searchName, lastPopupId, size);
         return SliceResponse.from(slice);
     }
 

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -155,10 +155,10 @@ public class PopupServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 운영중인_팝업_리스트_조회_openfeign {
+    class 내부용_팝업_목록을_조회할_때 {
         @Test
         @Transactional
-        void 운영중인_팝업의_리스트를_반환한다() {
+        void 운영중인_팝업이_존재하면_리스트를_반환한다() {
             LocalDate now = LocalDate.now();
 
             Long activePopup1 = createPopupWithDates("운영중인팝업1", now.minusDays(5), now.plusDays(10));
@@ -170,7 +170,8 @@ public class PopupServiceTest extends IntegrationTest {
             Long activePopup4 = createPopupWithDates("예정팝업1", now.plusDays(10), now.plusDays(20));
 
             // when
-            SliceResponse<PopupInfoResponse> response = popupService.findAllActivePopups(null, 10);
+            SliceResponse<PopupInfoResponse> response =
+                    popupService.findPopupsByNameWithPagination(null, null, 10);
 
             // then
             Assertions.assertAll(
@@ -194,7 +195,8 @@ public class PopupServiceTest extends IntegrationTest {
             createPopupWithDates("종료된팝업2", now.minusDays(20), now.minusDays(5));
 
             // when
-            SliceResponse<PopupInfoResponse> response = popupService.findAllActivePopups(null, 10);
+            SliceResponse<PopupInfoResponse> response =
+                    popupService.findPopupsByNameWithPagination(null, null, 10);
 
             // then
             Assertions.assertAll(
@@ -214,7 +216,8 @@ public class PopupServiceTest extends IntegrationTest {
             }
 
             // when - 첫 번째 페이지 (size=3)
-            SliceResponse<PopupInfoResponse> firstPage = popupService.findAllActivePopups(null, 3);
+            SliceResponse<PopupInfoResponse> firstPage =
+                    popupService.findPopupsByNameWithPagination(null, null, 3);
 
             // then
             Assertions.assertAll(
@@ -224,12 +227,64 @@ public class PopupServiceTest extends IntegrationTest {
             // when - 두 번째 페이지
             Long lastPopupId = firstPage.content().get(firstPage.content().size() - 1).popupId();
             SliceResponse<PopupInfoResponse> secondPage =
-                    popupService.findAllActivePopups(lastPopupId, 3);
+                    popupService.findPopupsByNameWithPagination(null, lastPopupId, 3);
 
             // then
             Assertions.assertAll(
                     () -> assertThat(secondPage.content()).hasSize(2),
                     () -> assertThat(secondPage.isLast()).isTrue());
+        }
+
+        @Test
+        @Transactional
+        void 검색어에_대한_결과가_존재하면_결과_리스트를_반환한다() {
+            // given
+            LocalDate now = LocalDate.now();
+
+            Long blackpinkPopup1 =
+                    createPopupWithDates("블랙핑크 팝업스토어", now.minusDays(5), now.plusDays(10));
+            Long blackpinkPopup2 =
+                    createPopupWithDates("BLACKPINK 굿즈샵", now.minusDays(1), now.plusDays(5));
+            createPopupWithDates("아이유 팝업", now.minusDays(1), now.plusDays(5));
+            createPopupWithDates("BTS 콘서트", now, now.plusDays(15));
+            createPopupWithDates("블랙핑크 종료팝업", now.minusDays(20), now.minusDays(1));
+
+            // when
+            SliceResponse<PopupInfoResponse> response =
+                    popupService.findPopupsByNameWithPagination("블랙핑크", null, 10);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content()).hasSize(1), // trim() 적용시 "블랙핑크"만 매칭
+                    () ->
+                            assertThat(response.content().get(0).popupId())
+                                    .isEqualTo(blackpinkPopup1),
+                    () -> assertThat(response.content().get(0).popupName()).contains("블랙핑크"),
+                    () -> assertThat(response.content().get(0).popupOpenDate()).isNotEmpty(),
+                    () -> assertThat(response.content().get(0).popupCloseDate()).isNotEmpty(),
+                    () -> assertThat(response.content().get(0).address()).isNotEmpty(),
+                    () -> assertThat(response.isLast()).isTrue());
+        }
+
+        @Test
+        @Transactional
+        void 검색어에_대해_결과가_없으면_빈_리스트를_반환한다() {
+            // given
+            LocalDate now = LocalDate.now();
+
+            createPopupWithDates("블랙핑크 팝업", now.minusDays(5), now.plusDays(10));
+            createPopupWithDates("아이유 팝업", now.minusDays(1), now.plusDays(5));
+            createPopupWithDates("BTS 콘서트", now, now.plusDays(15));
+
+            // when
+            SliceResponse<PopupInfoResponse> response =
+                    popupService.findPopupsByNameWithPagination("존재하지않는팝업", null, 10);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.content()).isEmpty(),
+                    () -> assertThat(response.content()).hasSize(0),
+                    () -> assertThat(response.isLast()).isTrue());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-195]

---
## 📌 작업 내용 및 특이사항

- 내부용 팝업 검색 API를 구현하였습니다.
- 기존 팝업 목록 조회 API와 통합하였으며, searchName의 포함 여부에 따라 전체 조회 또는 검색이 가능합니다.
- 팝업 검색에 성공한 경우 리스트를 반환하며, 검색 결과가 없는 경우 빈 리스트를 반환하는 테스트 코드를 작성하였으며, 별도의 예외 처리는 서비스 로직 흐름 상 추가하지 않았습니다.

---
## 📚 참고사항

-


[LCR-195]: https://lgcns-retail.atlassian.net/browse/LCR-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ