### PR TITLE
feat: Spring Cloud Kubernetes를 통한 서비스 디스커버리 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // Spring Cloud Kubernetes Discovery Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
+
+    // Spring Cloud Kubernetes Config Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
@@ -80,6 +86,12 @@ dependencies {
 
     // Slice & Pageable
     implementation 'org.springframework.data:spring-data-commons'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.0"
+    }
 }
 
 jar { enabled = true }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,10 @@ spring:
   config:
     activate:
       on-profile: "local"
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-222]

---
## 📌 작업 내용 및 특이사항

- Helm Chart의 `application-dev.yml` 값에 `spring.cloud.kubernetes.discovery.namespaces` 항목을 추가했습니다.
- 이를 통해 dev 환경에서 `popi-manager` 네임스페이스의 서비스를 디스커버리할 수 있도록 설정했습니다.
- 로컬 프로필에서는 Kubernetes 관련 설정이 적용되지 않도록 비활성화했습니다.

[LCR-222]: https://lgcns-retail.atlassian.net/browse/LCR-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ