### PR TITLE
feat: Internal 팝업 상세 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -21,20 +21,20 @@ public class ItemInternalController {
     @Operation(
             summary = "상품 목록 조회",
             description =
-                    "searchName을 포함하지 않으면 현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.</br>"
-                            + "searchName을 포함하여 호출하면 상품명에 searchName이 포함된 모든 상품을 페이징 처리한 뒤 반환합니다.")
+                    "keyword를 포함하지 않으면 현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.</br>"
+                            + "keyword를 포함하여 호출하면 상품명에 keyword가 포함된 모든 상품을 페이징 처리한 뒤 반환합니다.")
     public SliceResponse<ItemInfoResponse> userItemFindAll(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId,
             @Parameter(description = "검색할 상품 이름 (비워두면 모든 상품을 반환합니다.)", example = "블랙핑크")
-                    @RequestParam(name = "searchName", required = false)
-                    String searchName,
+                    @RequestParam(name = "keyword", required = false)
+                    String keyword,
             @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
                     @RequestParam(name = "lastItemId", required = false)
                     Long lastItemId,
             @Parameter(description = "페이지 크기 (기본 8)", example = "8")
                     @RequestParam(name = "size", defaultValue = "8")
                     int size) {
-        return itemService.findItemsByNameWithPagination(popupId, searchName, lastItemId, size);
+        return itemService.findItemsByNameWithPagination(popupId, keyword, lastItemId, size);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
@@ -9,5 +9,5 @@ public interface ItemRepositoryCustom {
     List<ItemLocationResponse> findItemsWithSplitLocation(Long popupId);
 
     Slice<ItemInfoResponse> findItemsByNameWithPagination(
-            Long popupId, String searchName, Long lastItemId, int size);
+            Long popupId, String keyword, Long lastItemId, int size);
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
@@ -49,7 +49,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
 
     @Override
     public Slice<ItemInfoResponse> findItemsByNameWithPagination(
-            Long popupId, String searchName, Long lastItemId, int size) {
+            Long popupId, String keyword, Long lastItemId, int size) {
         List<ItemInfoResponse> responses =
                 queryFactory
                         .select(
@@ -61,7 +61,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
                                         item.price))
                         .from(item)
                         .where(
-                                checkItemSearchName(searchName),
+                                checkItemSearchName(keyword),
                                 item.popup.id.eq(popupId),
                                 lastItemCondition(lastItemId))
                         .orderBy(item.id.desc())
@@ -71,8 +71,8 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
         return checkLastPage(size, responses);
     }
 
-    private BooleanExpression checkItemSearchName(String searchName) {
-        return StringUtils.hasText(searchName) ? item.name.contains(searchName) : null;
+    private BooleanExpression checkItemSearchName(String keyword) {
+        return StringUtils.hasText(keyword) ? item.name.contains(keyword) : null;
     }
 
     private BooleanExpression lastItemCondition(Long itemId) {

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -27,5 +27,5 @@ public interface ItemService {
             Long popupId, Long itemId, ItemMinStockUpdateRequest request);
 
     SliceResponse<ItemInfoResponse> findItemsByNameWithPagination(
-            Long popupId, String searchName, Long lastItemId, int size);
+            Long popupId, String keyword, Long lastItemId, int size);
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -144,9 +144,9 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<ItemInfoResponse> findItemsByNameWithPagination(
-            Long popupId, String searchName, Long lastItemId, int size) {
+            Long popupId, String keyword, Long lastItemId, int size) {
         Slice<ItemInfoResponse> itemInfoResponses =
-                itemRepository.findItemsByNameWithPagination(popupId, searchName, lastItemId, size);
+                itemRepository.findItemsByNameWithPagination(popupId, keyword, lastItemId, size);
 
         return SliceResponse.from(itemInfoResponses);
     }

--- a/src/main/java/com/lgcns/domain/popup/dto/response/PopupDetailsResponse.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/PopupDetailsResponse.java
@@ -1,0 +1,43 @@
+package com.lgcns.domain.popup.dto.response;
+
+public record PopupDetailsResponse(
+        Long popupId,
+        String popupName,
+        String imageUrl,
+        String popupOpenDate,
+        String popupCloseDate,
+        String reservationOpenDateTime,
+        String reservationCloseDateTime,
+        String address,
+        String runOpenTime,
+        String runCloseTime,
+        Double latitude,
+        Double longitude) {
+    public static PopupDetailsResponse of(
+            Long popupId,
+            String popupName,
+            String imageUrl,
+            String popupOpenDate,
+            String popupCloseDate,
+            String reservationOpenDateTime,
+            String reservationCloseDateTime,
+            String address,
+            String runOpenTime,
+            String runCloseTime,
+            Double latitude,
+            Double longitude) {
+        return new PopupDetailsResponse(
+                popupId,
+                popupName,
+                imageUrl,
+                popupOpenDate,
+                popupCloseDate,
+                reservationOpenDateTime,
+                reservationCloseDateTime,
+                address,
+                runOpenTime,
+                runCloseTime,
+                latitude,
+                longitude);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -24,19 +24,19 @@ public class PopupInternalController {
     @Operation(
             summary = "팝업 목록 조회",
             description =
-                    "searchName을 포함하지 않으면 현재 예약가능한 모든 팝업을 무한 스크롤을 위한 페이징 처리한 뒤 반환합니다.</br>"
-                            + "searchName을 포함하여 호출하면 팝업명에 searchName이 포함된 모든 팝업을 페이징 처리한 뒤 반환합니다.")
+                    "keyword을 포함하지 않으면 현재 예약가능한 모든 팝업을 무한 스크롤을 위한 페이징 처리한 뒤 반환합니다.</br>"
+                            + "keyword을 포함하여 호출하면 팝업명에 keyword이 포함된 모든 팝업을 페이징 처리한 뒤 반환합니다.")
     public SliceResponse<PopupInfoResponse> popupFindAll(
             @Parameter(description = "검색할 팝업 이름 (비워두면 모든 팝업을 반환합니다.)", example = "블랙핑크")
                     @RequestParam(required = false)
-                    String searchName,
+                    String keyword,
             @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
                     @RequestParam(required = false)
                     Long lastPopupId,
             @Parameter(description = "페이지 크기 (기본 8)", example = "8")
                     @RequestParam(defaultValue = "8")
                     int size) {
-        return popupService.findPopupsByNameWithPagination(searchName, lastPopupId, size);
+        return popupService.findPopupsByNameWithPagination(keyword, lastPopupId, size);
     }
 
     @GetMapping("/popups/{popupId}")

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.popup.internalApi;
 
+import com.lgcns.domain.popup.dto.response.PopupDetailsResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
 import com.lgcns.domain.popup.service.PopupService;
@@ -36,6 +37,12 @@ public class PopupInternalController {
                     @RequestParam(defaultValue = "8")
                     int size) {
         return popupService.findPopupsByNameWithPagination(searchName, lastPopupId, size);
+    }
+
+    @GetMapping("/popups/{popupId}")
+    @Operation(summary = "팝업 상세 조회", description = "팝업 ID를 통해 해당 팝업의 상세 정보를 조회합니다.")
+    public PopupDetailsResponse popupDetailsFind(@PathVariable Long popupId) {
+        return popupService.findPopupDetailsById(popupId);
     }
 
     @GetMapping("/reservations/popups/{popupId}/survey")

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -2,7 +2,6 @@ package com.lgcns.domain.popup.repository;
 
 import com.lgcns.domain.popup.dto.response.*;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Slice;
 
 public interface PopupRepositoryCustom {
@@ -14,5 +13,5 @@ public interface PopupRepositoryCustom {
     Slice<PopupInfoResponse> findPopupsByNameWithPagination(
             String searchName, Long lastPopupId, int size);
 
-    Optional<PopupDetailsResponse> findPopupDetailsById(Long popupId);
+    PopupDetailsResponse findPopupDetailsById(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.popup.repository;
 
 import com.lgcns.domain.popup.dto.response.*;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Slice;
 
 public interface PopupRepositoryCustom {
@@ -12,4 +13,6 @@ public interface PopupRepositoryCustom {
 
     Slice<PopupInfoResponse> findPopupsByNameWithPagination(
             String searchName, Long lastPopupId, int size);
+
+    Optional<PopupDetailsResponse> findPopupDetailsById(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -11,7 +11,7 @@ public interface PopupRepositoryCustom {
     List<ChoiceInfoResponse> findAllChoices(Long popupId);
 
     Slice<PopupInfoResponse> findPopupsByNameWithPagination(
-            String searchName, Long lastPopupId, int size);
+            String keyword, Long lastPopupId, int size);
 
     PopupDetailsResponse findPopupDetailsById(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -5,13 +5,16 @@ import static com.lgcns.domain.survey.domain.QChoice.choice;
 import static com.lgcns.domain.survey.domain.QSurvey.survey;
 
 import com.lgcns.domain.popup.dto.response.ChoiceInfoResponse;
+import com.lgcns.domain.popup.dto.response.PopupDetailsResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -51,10 +54,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                                         popup.imageUrl,
                                         popup.popupStartDate.stringValue(),
                                         popup.popupEndDate.stringValue(),
-                                        popup.address
-                                                .roadAddress
-                                                .concat(", ")
-                                                .concat(popup.address.detailAddress)))
+                                        getFullAddress()))
                         .from(popup)
                         .where(
                                 popup.popupEndDate.goe(LocalDate.now()),
@@ -81,6 +81,32 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public Optional<PopupDetailsResponse> findPopupDetailsById(Long popupId) {
+        PopupDetailsResponse result =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        PopupDetailsResponse.class,
+                                        popup.id,
+                                        popup.name,
+                                        popup.imageUrl,
+                                        popup.popupStartDate.stringValue(),
+                                        popup.popupEndDate.stringValue(),
+                                        popup.reservationOpenDateTime.stringValue(),
+                                        popup.reservationCloseDateTime.stringValue(),
+                                        getFullAddress(),
+                                        popup.runOpenTime.stringValue(),
+                                        popup.runCloseTime.stringValue(),
+                                        popup.address.latitude,
+                                        popup.address.longitude))
+                        .from(popup)
+                        .where(popup.id.eq(popupId))
+                        .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
     private BooleanExpression checkPopupSearchName(String searchName) {
         return StringUtils.hasText(searchName) ? popup.name.contains(searchName.trim()) : null;
     }
@@ -98,5 +124,9 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
         }
 
         return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+
+    private StringExpression getFullAddress() {
+        return popup.address.roadAddress.concat(", ").concat(popup.address.detailAddress);
     }
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -44,7 +44,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
 
     @Override
     public Slice<PopupInfoResponse> findPopupsByNameWithPagination(
-            String searchName, Long lastPopupId, int size) {
+            String keyword, Long lastPopupId, int size) {
         List<PopupInfoResponse> results =
                 jpaQueryFactory
                         .select(
@@ -59,7 +59,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                         .from(popup)
                         .where(
                                 popup.popupEndDate.goe(LocalDate.now()),
-                                checkPopupSearchName(searchName),
+                                checkPopupSearchName(keyword),
                                 lastPopupCondition(lastPopupId))
                         .orderBy(popup.createdAt.desc())
                         .limit(size + 1L)
@@ -112,8 +112,8 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
         return result;
     }
 
-    private BooleanExpression checkPopupSearchName(String searchName) {
-        return StringUtils.hasText(searchName) ? popup.name.contains(searchName.trim()) : null;
+    private BooleanExpression checkPopupSearchName(String keyword) {
+        return StringUtils.hasText(keyword) ? popup.name.contains(keyword.trim()) : null;
     }
 
     private BooleanExpression lastPopupCondition(Long popupId) {

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -8,13 +8,14 @@ import com.lgcns.domain.popup.dto.response.ChoiceInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupDetailsResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.exception.PopupErrorCode;
+import com.lgcns.global.error.exception.CustomException;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -82,7 +83,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
     }
 
     @Override
-    public Optional<PopupDetailsResponse> findPopupDetailsById(Long popupId) {
+    public PopupDetailsResponse findPopupDetailsById(Long popupId) {
         PopupDetailsResponse result =
                 jpaQueryFactory
                         .select(
@@ -104,7 +105,11 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                         .where(popup.id.eq(popupId))
                         .fetchOne();
 
-        return Optional.ofNullable(result);
+        if (result == null) {
+            throw new CustomException(PopupErrorCode.POPUP_NOT_FOUND);
+        }
+
+        return result;
     }
 
     private BooleanExpression checkPopupSearchName(String searchName) {

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -1,10 +1,7 @@
 package com.lgcns.domain.popup.service;
 
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
-import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
-import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
-import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
-import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
+import com.lgcns.domain.popup.dto.response.*;
 import com.lgcns.global.common.response.SliceResponse;
 import java.util.List;
 
@@ -19,4 +16,6 @@ public interface PopupService {
 
     SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(
             String searchName, Long lastPopupId, int size);
+
+    PopupDetailsResponse findPopupDetailsById(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -15,7 +15,7 @@ public interface PopupService {
     List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId);
 
     SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(
-            String searchName, Long lastPopupId, int size);
+            String keyword, Long lastPopupId, int size);
 
     PopupDetailsResponse findPopupDetailsById(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -115,9 +115,7 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     public PopupDetailsResponse findPopupDetailsById(Long popupId) {
-        return popupRepository
-                .findPopupDetailsById(popupId)
-                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
+        return popupRepository.findPopupDetailsById(popupId);
     }
 
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -85,9 +85,9 @@ public class PopupServiceImpl implements PopupService {
     @Override
     @Transactional(readOnly = true)
     public SliceResponse<PopupInfoResponse> findPopupsByNameWithPagination(
-            String searchName, Long lastPopupId, int size) {
+            String keyword, Long lastPopupId, int size) {
         Slice<PopupInfoResponse> slice =
-                popupRepository.findPopupsByNameWithPagination(searchName, lastPopupId, size);
+                popupRepository.findPopupsByNameWithPagination(keyword, lastPopupId, size);
         return SliceResponse.from(slice);
     }
 

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -113,6 +113,13 @@ public class PopupServiceImpl implements PopupService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public PopupDetailsResponse findPopupDetailsById(Long popupId) {
+        return popupRepository
+                .findPopupDetailsById(popupId)
+                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
+    }
+
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {
 
         return Popup.createPopup(

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -9,10 +9,7 @@ import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.dto.request.PopupCreateRequest;
 import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
-import com.lgcns.domain.popup.dto.response.PopupCreateResponse;
-import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
-import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
-import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
+import com.lgcns.domain.popup.dto.response.*;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.reservation.domain.Reservation;
@@ -307,6 +304,51 @@ public class PopupServiceTest extends IntegrationTest {
                 assertThat(choice.surveyId()).isNotNull();
                 assertThat(choice.options()).hasSize(4);
             }
+        }
+    }
+
+    @Nested
+    class 내부용_팝업_상세_정보를_조회할_떼 {
+
+        @Test
+        @Transactional
+        void 존재하는_팝업_아이디로_상세_조회에_성공한다() {
+            // given
+            Long popupId = createPopup();
+
+            // when
+            PopupDetailsResponse response = popupService.findPopupDetailsById(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(response.popupId()).isEqualTo(popupId),
+                    () -> assertThat(response.popupName()).isEqualTo("popup1"),
+                    () -> assertThat(response.imageUrl()).isEqualTo("https://bucket/asdf"),
+                    () -> assertThat(response.popupOpenDate()).isEqualTo("2025-01-01"),
+                    () -> assertThat(response.popupCloseDate()).isEqualTo("2025-01-31"),
+                    () ->
+                            assertThat(response.reservationOpenDateTime())
+                                    .isEqualTo("2025-01-01 10:00:00"),
+                    () ->
+                            assertThat(response.reservationCloseDateTime())
+                                    .isEqualTo("2025-01-31 20:00:00"),
+                    () -> assertThat(response.address()).isEqualTo("서울특별시 강남구 테헤란로 123, 3층 A호"),
+                    () -> assertThat(response.runOpenTime()).isEqualTo("10:00:00"),
+                    () -> assertThat(response.runCloseTime()).isEqualTo("20:00:00"),
+                    () -> assertThat(response.latitude()).isEqualTo(37.123456),
+                    () -> assertThat(response.longitude()).isEqualTo(127.123456));
+        }
+
+        @Test
+        @Transactional
+        void 존재하지_않는_팝업_아이디로_조회하면_예외를_발생시킨다() {
+            // given
+            final Long nonExistentPopupId = 999L;
+
+            // when & then
+            assertThatThrownBy(() -> popupService.findPopupDetailsById(nonExistentPopupId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-194]

---
## 📌 작업 내용 및 특이사항

- 상품 상세 조회 Internal API를 구현했습니다.
- 프론트엔드로 제공할 상품의 정보를 담는 DTO를 만들었습니다. feign client 쪽에서는 그냥 바로 반환하면 됩니다.
- 서비스 흐름상 popupId는 존재할 확률이 매우 높지만, 팝업이 갑작스럽게 삭제되는 경우를 대비하여 404 에러를 반환합니다.
- 응답 DTO에 맞는 Address를 구하는 로직이 중복되므로 `getFullAddress()` 메서드로 분리했습니다.
---
## 📚 참고사항

-


[LCR-194]: https://lgcns-retail.atlassian.net/browse/LCR-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ