### PR TITLE
feat: Internal 기본 상품 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -6,6 +6,7 @@ import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,5 +37,13 @@ public class ItemInternalController {
                     @RequestParam(name = "size", defaultValue = "8")
                     int size) {
         return itemService.findItemsByNameWithPagination(popupId, keyword, lastItemId, size);
+    }
+
+    @GetMapping("/default")
+    @Operation(summary = "기본 상품 목록 조회", description = "4개의 상품을 랜덤하게 조회합니다.")
+    public List<ItemInfoResponse> useItemFindDefault(
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId) {
+        return itemService.findRandomItems(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -40,7 +40,7 @@ public class ItemInternalController {
     }
 
     @GetMapping("/default")
-    @Operation(summary = "기본 상품 목록 조회", description = "4개의 상품을 랜덤하게 조회합니다.")
+    @Operation(summary = "기본 상품 목록 조회", description = "무작위하게 선택된 4개의 상품을 조회합니다.")
     public List<ItemInfoResponse> useItemFindDefault(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId) {

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -24,7 +24,7 @@ public class ItemInternalController {
             description =
                     "keyword를 포함하지 않으면 현재 팝업의 모든 상품을 무한 스크롤을 위하여 페이징 처리한 뒤 반환합니다.</br>"
                             + "keyword를 포함하여 호출하면 상품명에 keyword가 포함된 모든 상품을 페이징 처리한 뒤 반환합니다.")
-    public SliceResponse<ItemInfoResponse> userItemFindAll(
+    public SliceResponse<ItemInfoResponse> itemFindByName(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId,
             @Parameter(description = "검색할 상품 이름 (비워두면 모든 상품을 반환합니다.)", example = "블랙핑크")
@@ -41,7 +41,7 @@ public class ItemInternalController {
 
     @GetMapping("/default")
     @Operation(summary = "기본 상품 목록 조회", description = "무작위하게 선택된 4개의 상품을 조회합니다.")
-    public List<ItemInfoResponse> useItemFindDefault(
+    public List<ItemInfoResponse> itemFindDefault(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId) {
         return itemService.findRandomItems(popupId);

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface ItemRepositoryCustom {
 
     Slice<ItemInfoResponse> findItemsByNameWithPagination(
             Long popupId, String keyword, Long lastItemId, int size);
+
+    List<ItemInfoResponse> findRandomItems(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
@@ -1,12 +1,12 @@
 package com.lgcns.domain.item.repository;
 
 import static com.lgcns.domain.item.domain.QItem.item;
+import static com.querydsl.core.types.dsl.Expressions.*;
 
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -25,10 +25,8 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
 
     @Override
     public List<ItemLocationResponse> findItemsWithSplitLocation(Long popupId) {
-        StringExpression firstLetter =
-                Expressions.stringTemplate("SUBSTRING({0}, 1, 1)", item.location);
-        StringExpression lastLetter =
-                Expressions.stringTemplate("SUBSTRING({0}, 2)", item.location);
+        StringExpression firstLetter = stringTemplate("SUBSTRING({0}, 1, 1)", item.location);
+        StringExpression lastLetter = stringTemplate("SUBSTRING({0}, 2)", item.location);
 
         return queryFactory
                 .select(
@@ -71,8 +69,25 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
         return checkLastPage(size, responses);
     }
 
-    private BooleanExpression checkItemSearchName(String keyword) {
-        return StringUtils.hasText(keyword) ? item.name.contains(keyword) : null;
+    @Override
+    public List<ItemInfoResponse> findRandomItems(Long popupId) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ItemInfoResponse.class,
+                                item.id,
+                                item.name,
+                                item.imageUrl,
+                                item.price))
+                .from(item)
+                .where(item.popup.id.eq(popupId))
+                .orderBy(numberTemplate(Double.class, "RAND()").asc())
+                .limit(4)
+                .fetch();
+    }
+
+    private BooleanExpression checkItemSearchName(String searchName) {
+        return StringUtils.hasText(searchName) ? item.name.contains(searchName) : null;
     }
 
     private BooleanExpression lastItemCondition(Long itemId) {

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -28,4 +28,6 @@ public interface ItemService {
 
     SliceResponse<ItemInfoResponse> findItemsByNameWithPagination(
             Long popupId, String keyword, Long lastItemId, int size);
+
+    List<ItemInfoResponse> findRandomItems(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -151,6 +151,12 @@ public class ItemServiceImpl implements ItemService {
         return SliceResponse.from(itemInfoResponses);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<ItemInfoResponse> findRandomItems(Long popupId) {
+        return itemRepository.findRandomItems(popupId);
+    }
+
     private Popup findPopupById(Long popupId) {
         return popupRepository
                 .findById(popupId)

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -738,13 +738,13 @@ class ItemServiceTest extends IntegrationTest {
             itemRepository.save(item4);
 
             // when
-            List<ItemInfoResponse> result1 = itemService.findRandomItems(popupId);
+            List<ItemInfoResponse> result = itemService.findRandomItems(popupId);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(result1).isNotNull(),
-                    () -> assertThat(result1).hasSize(4),
-                    () -> assertThat(new HashSet<>(result1)).hasSize(result1.size()));
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(4),
+                    () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
         }
 
         @Test
@@ -768,13 +768,13 @@ class ItemServiceTest extends IntegrationTest {
             itemRepository.save(item3);
 
             // when
-            List<ItemInfoResponse> result1 = itemService.findRandomItems(popupId);
+            List<ItemInfoResponse> result = itemService.findRandomItems(popupId);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(result1).isNotNull(),
-                    () -> assertThat(result1).hasSize(3),
-                    () -> assertThat(new HashSet<>(result1)).hasSize(result1.size()));
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(3),
+                    () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
         }
     }
 }

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.apache.poi.ss.usermodel.Row;
@@ -708,6 +709,72 @@ class ItemServiceTest extends IntegrationTest {
                     () -> assertThat(result).isNotNull(),
                     () -> assertThat(result.content()).isEmpty(), // 빈 리스트 검증
                     () -> assertThat(result.isLast()).isTrue());
+        }
+    }
+
+    @Nested
+    class 내부용_기본_상품_목록을_조회할_때 {
+        @Test
+        @Transactional
+        void 무작위로_선택된_4개의_상품_조회에_성공한다() {
+            // given
+            final Long popupId = popup.getId();
+
+            Item item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+            Item item2 =
+                    Item.createItem(
+                            popup, "제니 포토카드", "https://bucket/jennie.jpg", 15000, 100, 10, "a2");
+            Item item3 =
+                    Item.createItem(
+                            popup, "로제 포토카드", "https://bucket/rose.jpg", 15000, 100, 10, "b1");
+            Item item4 =
+                    Item.createItem(popup, "리사 포토카드", "https://bucket/lisa.jpg", 5000, 50, 5, "b2");
+
+            itemRepository.save(item1);
+            itemRepository.save(item2);
+            itemRepository.save(item3);
+            itemRepository.save(item4);
+
+            // when
+            List<ItemInfoResponse> result1 = itemService.findRandomItems(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result1).isNotNull(),
+                    () -> assertThat(result1).hasSize(4),
+                    () -> assertThat(new HashSet<>(result1)).hasSize(result1.size()));
+        }
+
+        @Test
+        @Transactional
+        void 상품_데이터가_4개보다_적으면_전체_데이터_수_만큼_상품이_조회된다() {
+            // given
+            final Long popupId = popup.getId();
+
+            Item item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+            Item item2 =
+                    Item.createItem(
+                            popup, "제니 포토카드", "https://bucket/jennie.jpg", 15000, 100, 10, "a2");
+            Item item3 =
+                    Item.createItem(
+                            popup, "로제 포토카드", "https://bucket/rose.jpg", 15000, 100, 10, "b1");
+
+            itemRepository.save(item1);
+            itemRepository.save(item2);
+            itemRepository.save(item3);
+
+            // when
+            List<ItemInfoResponse> result1 = itemService.findRandomItems(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result1).isNotNull(),
+                    () -> assertThat(result1).hasSize(3),
+                    () -> assertThat(new HashSet<>(result1)).hasSize(result1.size()));
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-209]

---
## 📌 작업 내용 및 특이사항

- 내부용 기본 상품 목록 조회 API를 구현하였습니다.
- 상품 데이터가 4개 이상일 경우 무작위로 선택된 4개의 상품이 조회됩니다.
- 상품 데이터가 4개보다 적은 경우 전체 상품 데이터 수 만큼 조회됩니다.
- 기본 상품 목록 조회 기능 테스트 코드를 작성하였으며, 상품 데이터가 없는 경우에도 예외는 발생하지 않기 때문에 에외처리 관련 테스트는 작성하지 않았습니다.

---
## 📚 참고사항

-


[LCR-209]: https://lgcns-retail.atlassian.net/browse/LCR-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ