### PR TITLE
feat: Internal 결제 준비를 위한 상품 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/client/dto/request/ItemIdsForPaymentRequest.java
+++ b/src/main/java/com/lgcns/domain/item/client/dto/request/ItemIdsForPaymentRequest.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.item.client.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record ItemIdsForPaymentRequest(
+        @Schema(description = "결제할 아이템의 ID 리스트", example = "[1, 2, 4]") List<Long> itemIds) {}

--- a/src/main/java/com/lgcns/domain/item/client/dto/response/ItemForPaymentResponse.java
+++ b/src/main/java/com/lgcns/domain/item/client/dto/response/ItemForPaymentResponse.java
@@ -1,0 +1,3 @@
+package com.lgcns.domain.item.client.dto.response;
+
+public record ItemForPaymentResponse(Long itemId, String name, int price, int stock) {}

--- a/src/main/java/com/lgcns/domain/item/client/dto/response/ItemInfoResponse.java
+++ b/src/main/java/com/lgcns/domain/item/client/dto/response/ItemInfoResponse.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain.item.client.dto;
+package com.lgcns.domain.item.client.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -1,8 +1,8 @@
 package com.lgcns.domain.item.internalApi;
 
-import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
+import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.service.ItemService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -1,6 +1,8 @@
 package com.lgcns.domain.item.internalApi;
 
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
+import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.service.ItemService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,5 +47,16 @@ public class ItemInternalController {
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId) {
         return itemService.findRandomItems(popupId);
+    }
+
+    @PostMapping("/details")
+    @Operation(
+            summary = "결제용 상품 정보 조회",
+            description = "사용자가 장바구니에서 선택한 상품 ID 목록을 기반으로, 해당 팝업에 등록된 아이템들의 이름, 가격, 재고 정보를 반환합니다.")
+    public List<ItemForPaymentResponse> findItemDetail(
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId,
+            @RequestBody ItemIdsForPaymentRequest request) {
+        return itemService.findItemsForPayment(popupId, request);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.item.repository;
 
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
+import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import java.util.List;
 import org.springframework.data.domain.Slice;
@@ -12,4 +13,6 @@ public interface ItemRepositoryCustom {
             Long popupId, String keyword, Long lastItemId, int size);
 
     List<ItemInfoResponse> findRandomItems(Long popupId);
+
+    List<ItemForPaymentResponse> findItemsForPayment(Long popupId, List<Long> itemIds);
 }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.lgcns.domain.item.repository;
 
-import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
+import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import java.util.List;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.lgcns.domain.item.domain.QItem.item;
 import static com.querydsl.core.types.dsl.Expressions.*;
 
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
+import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -83,6 +84,21 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
                 .where(item.popup.id.eq(popupId))
                 .orderBy(numberTemplate(Double.class, "RAND()").asc())
                 .limit(4)
+                .fetch();
+    }
+
+    @Override
+    public List<ItemForPaymentResponse> findItemsForPayment(Long popupId, List<Long> itemIds) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ItemForPaymentResponse.class,
+                                item.id,
+                                item.name,
+                                item.price,
+                                item.stock))
+                .from(item)
+                .where(item.popup.id.eq(popupId), item.id.in(itemIds))
                 .fetch();
     }
 

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepositoryImpl.java
@@ -3,8 +3,8 @@ package com.lgcns.domain.item.repository;
 import static com.lgcns.domain.item.domain.QItem.item;
 import static com.querydsl.core.types.dsl.Expressions.*;
 
-import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
+import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.dto.response.ItemLocationResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -1,6 +1,8 @@
 package com.lgcns.domain.item.service;
 
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
+import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;
@@ -30,4 +32,7 @@ public interface ItemService {
             Long popupId, String keyword, Long lastItemId, int size);
 
     List<ItemInfoResponse> findRandomItems(Long popupId);
+
+    List<ItemForPaymentResponse> findItemsForPayment(
+            Long popupId, ItemIdsForPaymentRequest request);
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -1,8 +1,8 @@
 package com.lgcns.domain.item.service;
 
-import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
+import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -1,8 +1,8 @@
 package com.lgcns.domain.item.service;
 
-import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
+import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -1,6 +1,8 @@
 package com.lgcns.domain.item.service;
 
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
+import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
@@ -155,6 +157,13 @@ public class ItemServiceImpl implements ItemService {
     @Transactional(readOnly = true)
     public List<ItemInfoResponse> findRandomItems(Long popupId) {
         return itemRepository.findRandomItems(popupId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ItemForPaymentResponse> findItemsForPayment(
+            Long popupId, ItemIdsForPaymentRequest request) {
+        return itemRepository.findItemsForPayment(popupId, request.itemIds());
     }
 
     private Popup findPopupById(Long popupId) {

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -2,9 +2,12 @@ package com.lgcns.domain.item.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.item.client.dto.ItemInfoResponse;
+import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
+import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
@@ -775,6 +778,91 @@ class ItemServiceTest extends IntegrationTest {
                     () -> assertThat(result).isNotNull(),
                     () -> assertThat(result).hasSize(3),
                     () -> assertThat(new HashSet<>(result)).hasSize(result.size()));
+        }
+    }
+
+    @Nested
+    class 결제_준비용_상품_상세_목록을_조회할_때 {
+
+        @Test
+        @Transactional
+        void 요청한_itemId_목록에_해당하는_상품_정보를_반환한다() {
+            // given
+            final Long popupId = popup.getId();
+
+            Item item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+            Item item2 =
+                    Item.createItem(
+                            popup, "제니 포토카드", "https://bucket/jennie.jpg", 15000, 100, 10, "a2");
+            itemRepository.saveAll(List.of(item1, item2));
+
+            ItemIdsForPaymentRequest request =
+                    new ItemIdsForPaymentRequest(List.of(item1.getId(), item2.getId()));
+
+            // when
+            List<ItemForPaymentResponse> result = itemService.findItemsForPayment(popupId, request);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () ->
+                            assertThat(result)
+                                    .extracting("itemId", "name", "price", "stock")
+                                    .containsExactlyInAnyOrder(
+                                            tuple(
+                                                    item1.getId(),
+                                                    item1.getName(),
+                                                    item1.getPrice(),
+                                                    item1.getStock()),
+                                            tuple(
+                                                    item2.getId(),
+                                                    item2.getName(),
+                                                    item2.getPrice(),
+                                                    item2.getStock())));
+        }
+
+        @Test
+        @Transactional
+        void 존재하지_않는_itemId가_포함된_경우_해당_상품을_제외하고_존재하는_상품_정보만_반환한다() {
+            // given
+            final Long popupId = popup.getId();
+
+            Item item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+            Item item2 =
+                    Item.createItem(
+                            popup, "제니 포토카드", "https://bucket/jennie.jpg", 15000, 100, 10, "a2");
+            Item item3 =
+                    Item.createItem(
+                            popup, "로제 포토카드", "https://bucket/rose.jpg", 15000, 100, 10, "b1");
+            itemRepository.saveAll(List.of(item1, item2, item3));
+
+            ItemIdsForPaymentRequest request =
+                    new ItemIdsForPaymentRequest(List.of(item1.getId(), 999L, item3.getId()));
+
+            // when
+            List<ItemForPaymentResponse> result = itemService.findItemsForPayment(popupId, request);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () ->
+                            assertThat(result)
+                                    .extracting("itemId", "name", "price", "stock")
+                                    .containsExactlyInAnyOrder(
+                                            tuple(
+                                                    item1.getId(),
+                                                    item1.getName(),
+                                                    item1.getPrice(),
+                                                    item1.getStock()),
+                                            tuple(
+                                                    item3.getId(),
+                                                    item3.getName(),
+                                                    item3.getPrice(),
+                                                    item3.getStock())));
         }
     }
 }

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import com.lgcns.IntegrationTest;
-import com.lgcns.domain.item.client.dto.ItemInfoResponse;
 import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
+import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-237]

---
## 📌 작업 내용 및 특이사항

- 결제 준비를 위한 상품 상세 조회 Internal API를 추가했습니다.
- popupId와 itemIds를 기반으로 이름, 가격, 재고 정보를 반환합니다.
- 존재하지 않는 ID는 무시하고, 존재하는 상품만 조회되도록 처리했습니다.
- 해당 API는 결제 서비스에서 결제 준비 단계에 Feign으로 호출되어 사용자가 장바구니에서 선택한 상품의 정확한 정보(name, price, stock)를 확인하고 결제 금액을 계산하는 데 사용됩니다.


[LCR-237]: https://lgcns-retail.atlassian.net/browse/LCR-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ