### PR TITLE
feat: Internal 예약 정보 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -46,7 +46,7 @@ public class PopupInternalController {
         return popupService.findPopupDetailsById(popupId);
     }
 
-    @GetMapping("/reservations/{popupId}/survey")
+    @GetMapping("/reservations/popups/{popupId}/survey")
     @Operation(summary = "팝업에 등록된 설문지 목록 조회", description = "팝업 ID를 통해 등록된 설문지 목록을 조회합니다.")
     public List<SurveyChoiceResponse> choiceListByPopupIdFind(@PathVariable Long popupId) {
         return popupService.findAllChoicesByPopupId(popupId);

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -46,7 +46,7 @@ public class PopupInternalController {
         return popupService.findPopupDetailsById(popupId);
     }
 
-    @GetMapping("/reservations/popups/{popupId}/survey")
+    @GetMapping("/reservations/{popupId}/survey")
     @Operation(summary = "팝업에 등록된 설문지 목록 조회", description = "팝업 ID를 통해 등록된 설문지 목록을 조회합니다.")
     public List<SurveyChoiceResponse> choiceListByPopupIdFind(@PathVariable Long popupId) {
         return popupService.findAllChoicesByPopupId(popupId);

--- a/src/main/java/com/lgcns/domain/reservation/dto/response/ReservationInfoResponse.java
+++ b/src/main/java/com/lgcns/domain/reservation/dto/response/ReservationInfoResponse.java
@@ -1,0 +1,12 @@
+package com.lgcns.domain.reservation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ReservationInfoResponse(
+        Long popupId, LocalDate reservationDate, LocalTime reservationTime) {
+    public static ReservationInfoResponse of(
+            Long popupId, LocalDate reservationDate, LocalTime reservationTime) {
+        return new ReservationInfoResponse(popupId, reservationDate, reservationTime);
+    }
+}

--- a/src/main/java/com/lgcns/domain/reservation/exception/ReservationErrorCode.java
+++ b/src/main/java/com/lgcns/domain/reservation/exception/ReservationErrorCode.java
@@ -1,0 +1,16 @@
+package com.lgcns.domain.reservation.exception;
+
+import com.lgcns.global.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReservationErrorCode implements ErrorCode {
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
+++ b/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
@@ -16,7 +16,7 @@ public class ReservationInternalController {
 
     private final ReservationService reservationService;
 
-    @GetMapping("/{popupId}")
+    @GetMapping("/popups/{popupId}")
     @Operation(summary = "해당 달에 대한 예약 목록 조회", description = "팝업스토어 ID와 달을 통해 예약 정보를 조회합니다.")
     public MonthlyReservationResponse findReservationByIdAndDate(
             @PathVariable Long popupId, @RequestParam String date) {

--- a/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
+++ b/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
@@ -16,7 +16,7 @@ public class ReservationInternalController {
 
     private final ReservationService reservationService;
 
-    @GetMapping("/popups/{popupId}")
+    @GetMapping("/{popupId}")
     @Operation(summary = "해당 달에 대한 예약 목록 조회", description = "팝업스토어 ID와 달을 통해 예약 정보를 조회합니다.")
     public MonthlyReservationResponse findReservationByIdAndDate(
             @PathVariable Long popupId, @RequestParam String date) {

--- a/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
+++ b/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.reservation.internalApi;
 
 import com.lgcns.domain.reservation.dto.response.MonthlyReservationResponse;
+import com.lgcns.domain.reservation.dto.response.ReservationInfoResponse;
 import com.lgcns.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,5 +21,11 @@ public class ReservationInternalController {
     public MonthlyReservationResponse findReservationByIdAndDate(
             @PathVariable Long popupId, @RequestParam String date) {
         return reservationService.findReservationByIdAndDate(popupId, date);
+    }
+
+    @GetMapping("/{reservationId}")
+    @Operation(summary = "예약 상세 정보 조회", description = "예약 ID를 통해 예약의 상세 정보를 조회합니다.")
+    public ReservationInfoResponse findReservationById(@PathVariable Long reservationId) {
+        return reservationService.findReservationById(reservationId);
     }
 }

--- a/src/main/java/com/lgcns/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/lgcns/domain/reservation/service/ReservationService.java
@@ -1,8 +1,11 @@
 package com.lgcns.domain.reservation.service;
 
 import com.lgcns.domain.reservation.dto.response.MonthlyReservationResponse;
+import com.lgcns.domain.reservation.dto.response.ReservationInfoResponse;
 
 public interface ReservationService {
 
     MonthlyReservationResponse findReservationByIdAndDate(Long popupId, String date);
+
+    ReservationInfoResponse findReservationById(Long reservationId);
 }

--- a/src/main/java/com/lgcns/domain/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/reservation/service/ReservationServiceImpl.java
@@ -3,8 +3,11 @@ package com.lgcns.domain.reservation.service;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
+import com.lgcns.domain.reservation.domain.Reservation;
 import com.lgcns.domain.reservation.dto.response.DailyReservation;
 import com.lgcns.domain.reservation.dto.response.MonthlyReservationResponse;
+import com.lgcns.domain.reservation.dto.response.ReservationInfoResponse;
+import com.lgcns.domain.reservation.exception.ReservationErrorCode;
 import com.lgcns.domain.reservation.repository.ReservationRepository;
 import com.lgcns.global.error.exception.CustomException;
 import java.util.List;
@@ -36,5 +39,20 @@ public class ReservationServiceImpl implements ReservationService {
                 popup.getPopupEndDate(),
                 popup.getTimeCapacity(),
                 dailyReservationList);
+    }
+
+    @Override
+    public ReservationInfoResponse findReservationById(Long reservationId) {
+        Reservation reservation =
+                reservationRepository
+                        .findById(reservationId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ReservationErrorCode.RESERVATION_NOT_FOUND));
+        return ReservationInfoResponse.of(
+                reservation.getPopup().getId(),
+                reservation.getReservationDate(),
+                reservation.getReservationTime());
     }
 }

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -44,7 +44,6 @@ public class PopupServiceTest extends IntegrationTest {
 
     private Manager ownerManager;
     private Manager otherManager;
-    private Popup popup;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/lgcns/domain/reservation/service/reservationServiceTest.java
+++ b/src/test/java/com/lgcns/domain/reservation/service/reservationServiceTest.java
@@ -12,7 +12,11 @@ import com.lgcns.domain.popup.dto.request.PopupWithChoicesCreateRequest;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.popup.service.PopupService;
+import com.lgcns.domain.reservation.domain.Reservation;
 import com.lgcns.domain.reservation.dto.response.MonthlyReservationResponse;
+import com.lgcns.domain.reservation.dto.response.ReservationInfoResponse;
+import com.lgcns.domain.reservation.exception.ReservationErrorCode;
+import com.lgcns.domain.reservation.repository.ReservationRepository;
 import com.lgcns.domain.survey.dto.request.ChoiceCreateRequest;
 import com.lgcns.global.error.exception.CustomException;
 import java.time.LocalDate;
@@ -32,6 +36,7 @@ public class reservationServiceTest extends IntegrationTest {
     @Autowired private PopupService popupService;
     @Autowired private PopupRepository popupRepository;
     @Autowired private ManagerRepository managerRepository;
+    @Autowired private ReservationRepository reservationRepository;
 
     private Manager manager;
     private Popup popup;
@@ -46,9 +51,9 @@ public class reservationServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 팝업에_대한_예약_날짜_조회 {
+    class 팝업에_대한_예약_날짜_조회_할_때 {
         @Test
-        void 예약_날짜_조회_성공() {
+        void 예약_날짜_조회_성공한다() {
             // given
             Long popupId = popup.getId();
 
@@ -95,7 +100,7 @@ public class reservationServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 예약_날짜_조회_실패() {
+        void 예약_날짜_조회_실패한다() {
             // given
             Long popupId = 999L; // 존재하지 않는 팝업 ID
             String date = "2023-10-01";
@@ -104,6 +109,40 @@ public class reservationServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> reservationService.findReservationByIdAndDate(popupId, date))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(PopupErrorCode.POPUP_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 예약_정보를_조회할_때 {
+
+        @Test
+        void 예약_정보_조회에_성공한다() {
+            // given
+            Reservation reservation = reservationRepository.findAllByPopupId(popup.getId()).get(0);
+            // when
+            ReservationInfoResponse reservationInfoResponse =
+                    reservationService.findReservationById(reservation.getId());
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(reservationInfoResponse.popupId()).isEqualTo(popup.getId()),
+                    () ->
+                            assertThat(reservationInfoResponse.reservationDate())
+                                    .isEqualTo(reservation.getReservationDate()),
+                    () ->
+                            assertThat(reservationInfoResponse.reservationTime())
+                                    .isEqualTo(reservation.getReservationTime()));
+        }
+
+        @Test
+        void 예약_정보_조회에_실패한다() {
+            // given
+            Long reservationId = -1L; // 존재하지 않는 예약 ID
+
+            // when & then
+            assertThatThrownBy(() -> reservationService.findReservationById(reservationId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining(ReservationErrorCode.RESERVATION_NOT_FOUND.getMessage());
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-219]

---
## 📌 작업 내용 및 특이사항

- 예약 정보를 반환하는 FeignClient용 Internal API 구현했습니다.
- 기존 /reservation/popups/... 엔드포인트에서 popups 제거했습니다.

[LCR-219]: https://lgcns-retail.atlassian.net/browse/LCR-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ