### PR TITLE
feat: Internal 인기 팝업 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -57,4 +57,9 @@ public class PopupInternalController {
     public List<PopupDetailsResponse> findReservedPopupInfo(@RequestBody PopupIdsRequest request) {
         return popupService.findReservedPopupInfo(request);
     }
+
+    @PostMapping("popups/hot")
+    public List<PopupInfoResponse> hotPopupsFind(@RequestBody List<Long> popupIds) {
+        return popupService.findPopupsByIds(popupIds);
+    }
 }

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -58,7 +58,7 @@ public class PopupInternalController {
         return popupService.findReservedPopupInfo(request);
     }
 
-    @PostMapping("popups/hot")
+    @PostMapping("popups/popularity")
     public List<PopupInfoResponse> hotPopupsFind(@RequestBody List<Long> popupIds) {
         return popupService.findPopupsByIds(popupIds);
     }

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -59,7 +59,7 @@ public class PopupInternalController {
     }
 
     @PostMapping("popups/popularity")
-    public List<PopupInfoResponse> hotPopupsFind(@RequestBody List<Long> popupIds) {
-        return popupService.findPopupsByIds(popupIds);
+    public List<PopupInfoResponse> hotPopupsFind(@RequestBody PopupIdsRequest request) {
+        return popupService.findPopupsByIds(request);
     }
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -16,4 +16,6 @@ public interface PopupRepositoryCustom {
     PopupDetailsResponse findPopupDetailsById(Long popupId);
 
     List<PopupDetailsResponse> findReservedPopupInfo(List<Long> popupIds);
+
+    List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -15,7 +15,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -138,10 +137,6 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
 
     @Override
     public List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds) {
-        if (popupIds == null || popupIds.isEmpty()) {
-            return new ArrayList<>();
-        }
-
         return jpaQueryFactory
                 .select(
                         Projections.constructor(

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -133,6 +134,28 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
         }
 
         return result;
+    }
+
+    @Override
+    public List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds) {
+        if (popupIds == null || popupIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                PopupInfoResponse.class,
+                                popup.id,
+                                popup.name,
+                                popup.imageUrl,
+                                popup.popupStartDate.stringValue(),
+                                popup.popupEndDate.stringValue(),
+                                getFullAddress()))
+                .from(popup)
+                .where(popup.id.in(popupIds))
+                .orderBy(popup.id.asc())
+                .fetch();
     }
 
     private BooleanExpression checkPopupSearchName(String keyword) {

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -155,6 +155,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .from(popup)
                 .where(popup.id.in(popupIds))
                 .orderBy(popup.id.asc())
+                .limit(4)
                 .fetch();
     }
 

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -22,5 +22,5 @@ public interface PopupService {
 
     List<PopupDetailsResponse> findReservedPopupInfo(PopupIdsRequest request);
 
-    List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds);
+    List<PopupInfoResponse> findPopupsByIds(PopupIdsRequest request);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -21,4 +21,6 @@ public interface PopupService {
     PopupDetailsResponse findPopupDetailsById(Long popupId);
 
     List<PopupDetailsResponse> findReservedPopupInfo(PopupIdsRequest request);
+
+    List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds);
 }

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -125,8 +125,8 @@ public class PopupServiceImpl implements PopupService {
     }
 
     @Override
-    public List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds) {
-        return popupRepository.findPopupsByIds(popupIds);
+    public List<PopupInfoResponse> findPopupsByIds(PopupIdsRequest request) {
+        return popupRepository.findPopupsByIds(request.popupIds());
     }
 
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -124,6 +124,11 @@ public class PopupServiceImpl implements PopupService {
         return popupRepository.findReservedPopupInfo(request.popupIds());
     }
 
+    @Override
+    public List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds) {
+        return popupRepository.findPopupsByIds(popupIds);
+    }
+
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {
 
         return Popup.createPopup(

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -391,10 +391,11 @@ public class PopupServiceTest extends IntegrationTest {
             Long popupId2 = createPopup();
             Long popupId3 = createPopup();
             Long popupId4 = createPopup();
-            List<Long> popupIds = List.of(popupId1, popupId2, popupId3, popupId4);
+            PopupIdsRequest request =
+                    new PopupIdsRequest(List.of(popupId1, popupId2, popupId3, popupId4));
 
             // when
-            List<PopupInfoResponse> results = popupService.findPopupsByIds(popupIds);
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
 
             // then
             assertThat(results).hasSize(4);
@@ -411,10 +412,11 @@ public class PopupServiceTest extends IntegrationTest {
             Long popupId3 = createPopup();
             Long popupId4 = createPopup();
             Long popupId5 = createPopup();
-            List<Long> popupIds = List.of(popupId1, popupId2, popupId3, popupId4, popupId5);
+            PopupIdsRequest request =
+                    new PopupIdsRequest(List.of(popupId1, popupId2, popupId3, popupId4, popupId5));
 
             // when
-            List<PopupInfoResponse> results = popupService.findPopupsByIds(popupIds);
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
 
             // then
             assertThat(results).hasSize(4);
@@ -428,10 +430,10 @@ public class PopupServiceTest extends IntegrationTest {
             // given
             Long popupId1 = createPopup();
             Long popupId2 = createPopup();
-            List<Long> popupIds = List.of(popupId1, popupId2);
+            PopupIdsRequest request = new PopupIdsRequest(List.of(popupId1, popupId2));
 
             // when
-            List<PopupInfoResponse> results = popupService.findPopupsByIds(popupIds);
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
 
             // then
             assertThat(results).hasSize(2);

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -1,8 +1,5 @@
 package com.lgcns.domain.popup.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
@@ -22,16 +19,20 @@ import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
 import com.lgcns.global.common.response.SliceResponse;
 import com.lgcns.global.error.exception.CustomException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PopupServiceTest extends IntegrationTest {
     @Autowired private PopupService popupService;
@@ -57,7 +58,7 @@ public class PopupServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 팝업_등록 {
+    class 팝업을_등록할_때 {
         @Test
         @Transactional
         void 유효한_입력_값이면_팝업_등록에_성공한다() {
@@ -91,7 +92,7 @@ public class PopupServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 팝업_목록_조회 {
+    class 팝업_목록을_조회할_때 {
         @Test
         @Transactional
         void 팝업_목록_조회에_성공한다() {
@@ -111,10 +112,10 @@ public class PopupServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 팝업_삭제 {
+    class 팝업을_삭제할_때 {
         @Test
         @Transactional
-        void 정상적으로_팝업을_삭제한다() {
+        void 정상적으로_팝업이_삭제된다() {
             // given
             Long popupId = createPopup();
 
@@ -377,6 +378,66 @@ public class PopupServiceTest extends IntegrationTest {
             assertThat(popupDetail.address()).isEqualTo("서울특별시 강남구 테헤란로 123, 3층 A호");
             assertThat(popupDetail.latitude()).isEqualTo(37.123456);
             assertThat(popupDetail.longitude()).isEqualTo(127.123456);
+        }
+    }
+
+    @Nested
+    class 팝업_아이디_리스트로_팝업_정보_리스트를_조회할_때 {
+
+        @Test
+        @Transactional
+        void 정상적으로_리스트_조회에_성공한다() {
+            // given
+            Long popupId1 = createPopup();
+            Long popupId2 = createPopup();
+            Long popupId3 = createPopup();
+            Long popupId4 = createPopup();
+            List<Long> popupIds = List.of(popupId1, popupId2, popupId3, popupId4);
+
+            // when
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(popupIds);
+
+            // then
+            assertThat(results).hasSize(4);
+            List<Long> resultIds = results.stream().map(PopupInfoResponse::popupId).toList();
+            assertThat(resultIds).containsExactlyInAnyOrder(popupId1, popupId2, popupId3, popupId4);
+        }
+
+        @Test
+        @Transactional
+        void 팝업_아이디_리스트의_크기가_4보다_큰_경우에도_4개의_팝업_정보_리스트만_반환한다() {
+            // given
+            Long popupId1 = createPopup();
+            Long popupId2 = createPopup();
+            Long popupId3 = createPopup();
+            Long popupId4 = createPopup();
+            Long popupId5 = createPopup();
+            List<Long> popupIds = List.of(popupId1, popupId2, popupId3, popupId4, popupId5);
+
+            // when
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(popupIds);
+
+            // then
+            assertThat(results).hasSize(4);
+            List<Long> resultIds = results.stream().map(PopupInfoResponse::popupId).toList();
+            assertThat(resultIds).containsExactlyInAnyOrder(popupId1, popupId2, popupId3, popupId4);
+        }
+
+        @Test
+        @Transactional
+        void 팝업_아이디_리스트의_크기가_4보다_작은_경우에도_해당_크기의_팝업_정보_리스트를_반환한다() {
+            // given
+            Long popupId1 = createPopup();
+            Long popupId2 = createPopup();
+            List<Long> popupIds = List.of(popupId1, popupId2);
+
+            // when
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(popupIds);
+
+            // then
+            assertThat(results).hasSize(2);
+            List<Long> resultIds = results.stream().map(PopupInfoResponse::popupId).toList();
+            assertThat(resultIds).containsExactlyInAnyOrder(popupId1, popupId2);
         }
     }
 

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -1,5 +1,8 @@
 package com.lgcns.domain.popup.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
@@ -19,20 +22,16 @@ import com.lgcns.domain.survey.repository.ChoiceRepository;
 import com.lgcns.domain.survey.repository.SurveyRepository;
 import com.lgcns.global.common.response.SliceResponse;
 import com.lgcns.global.error.exception.CustomException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PopupServiceTest extends IntegrationTest {
     @Autowired private PopupService popupService;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-235]

---
## 📌 작업 내용 및 특이사항

- 인기 팝업 (최대 4개) 리스트를 조회하는 내부 API를 구현했습니다.
- user-server/ poup-service의 메인 페이지 진입 시 호촐되는 내부 API입니다.
- 예외 처리 로직은 따로 작성하지 않았습니다.

---
## 📚 참고사항

-


[LCR-235]: https://lgcns-retail.atlassian.net/browse/LCR-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ