### PR TITLE
feat: Eureka 클라이언트 등록 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // Eureka Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     // Spring Cloud Kubernetes Discovery Client
     implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client'
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,3 +13,11 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+
+eureka:
+  instance:
+    instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+    leaseRenewalIntervalInSeconds: 10
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: managers
   profiles:
     group:
       test: "test"


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-247]

---
## 📌 작업 내용 및 특이사항

- 매니저 서비스에서 유저의 예약 서비스에 Feign Client 호출을 위해 Eureka Client 설정을 추가하였습니다.
- 각 마이크로서비스가 랜덤 포트로 실행되기 때문에, FeignClient의 url 속성을 직접 지정하는 방식은 비효율적이었습니다.
- 이를 해결하기 위해 Eureka를 통해 서비스 이름 기반의 디스커버리 방식으로 호출할 수 있도록 개선하였습니다.

[LCR-247]: https://lgcns-retail.atlassian.net/browse/LCR-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ