### PR TITLE
feat: Feign 클라이언트용 커스텀 예외 디코딩 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
-
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -71,7 +70,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
 
     // S3
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
@@ -86,6 +84,9 @@ dependencies {
 
     // Slice & Pageable
     implementation 'org.springframework.data:spring-data-commons'
+
+    // Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ def jacocoExcludePatterns = [
         "**/*Details*",
         "**/*Error*/**",
         "**/resources/**",
+        "**/error/**",
         "**/exception/**",
         "**/config/**",
         "**/internalApi/**",

--- a/src/main/java/com/lgcns/global/config/feign/FeignConfig.java
+++ b/src/main/java/com/lgcns/global/config/feign/FeignConfig.java
@@ -1,0 +1,17 @@
+package com.lgcns.global.config.feign;
+
+import com.lgcns.global.error.feign.FeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.lgcns")
+public class FeignConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new FeignErrorDecoder();
+    }
+}

--- a/src/main/java/com/lgcns/global/error/feign/FeignErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/feign/FeignErrorCode.java
@@ -1,0 +1,25 @@
+package com.lgcns.global.error.feign;
+
+import com.lgcns.global.error.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public record FeignErrorCode(String errorName, String message, int statusCode)
+        implements ErrorCode {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.resolve(statusCode) != null
+                ? HttpStatus.resolve(statusCode)
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getErrorName() {
+        return errorName;
+    }
+}

--- a/src/main/java/com/lgcns/global/error/feign/FeignErrorDecoder.java
+++ b/src/main/java/com/lgcns/global/error/feign/FeignErrorDecoder.java
@@ -1,0 +1,30 @@
+package com.lgcns.global.error.feign;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.global.error.exception.CustomException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import java.io.InputStream;
+
+public class FeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder defaultDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        try (InputStream body = response.body().asInputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode errorBody = objectMapper.readTree(body);
+
+            String errorClassName =
+                    errorBody.path("data").path("errorClassName").asText("FEIGN_ERROR");
+            String message = errorBody.path("data").path("message").asText("Feign 예외 디코딩 실패");
+
+            return new CustomException(
+                    new FeignErrorCode(errorClassName, message, response.status()));
+        } catch (Exception e) {
+            return defaultDecoder.decode(methodKey, response);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-248]

---
## 📌 작업 내용 및 특이사항

- Feign 통신 중 발생한 예외를 GlobalResponse 구조로 디코딩하는 커스텀 예외 디코더를 구현했습니다.
- 응답에서 errorClassName, message, statusCode를 추출해 FeignErrorCode로 매핑하고, CustomException을 생성해 처리합니다.
- 디코딩 실패 시 DefaultErrorDecoder로 fallback 하도록 구성했습니다.
- 매니저와 유저 서비스 간 예외가 500으로 포장되던 문제를 해결하고, 정의된 에러 메시지와 상태코드가 그대로 전달되도록 개선했습니다.

---
## 📚 참고사항

- 본 커스텀 예외 디코딩 로직은 공통 모듈(common)의 FeignConfig에서 설정됩니다.
- 각 마이크로서비스에서 Feign 클라이언트를 사용할 경우, @FeignClient 어노테이션에 다음과 같이 configuration 속성을 지정해야 공통 예외 디코더가 적용됩니다.

```java
@FeignClient(name = "reservations", url = "${reservation.service.url}", configuration = FeignConfig.class)
public interface ReservationServiceClient {}
```

[LCR-248]: https://lgcns-retail.atlassian.net/browse/LCR-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ