### PR TITLE
fix: Internal 인기 팝업 리스트 조회 기능 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -17,5 +17,7 @@ public interface PopupRepositoryCustom {
 
     List<PopupDetailsResponse> findReservedPopupInfo(List<Long> popupIds);
 
-    List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds);
+    List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds, int limit);
+
+    List<PopupInfoResponse> findRandomPopups(List<Long> excludeIds, int size);
 }

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -14,10 +14,13 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -151,7 +154,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                                 getFullAddress()))
                 .from(popup)
                 .where(popup.id.in(popupIds))
-                .orderBy(popup.id.asc())
+                .orderBy(createOrderByPopupIds(popupIds).asc())
                 .limit(limit)
                 .fetch();
     }
@@ -173,6 +176,16 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .orderBy(randomOrder())
                 .limit(size)
                 .fetch();
+    }
+
+    private NumberExpression<Integer> createOrderByPopupIds(List<Long> popupIds) {
+        String caseWhenClause =
+                IntStream.range(0, popupIds.size())
+                        .mapToObj(i -> "WHEN {" + i + "} = popup.id THEN " + i)
+                        .collect(Collectors.joining(" "));
+
+        return Expressions.numberTemplate(
+                Integer.class, "CASE " + caseWhenClause + " END", popupIds.toArray());
     }
 
     private OrderSpecifier<Double> randomOrder() {

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -10,8 +10,10 @@ import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
 import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.global.error.exception.CustomException;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
@@ -136,7 +138,7 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
     }
 
     @Override
-    public List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds) {
+    public List<PopupInfoResponse> findPopupsByIds(List<Long> popupIds, int limit) {
         return jpaQueryFactory
                 .select(
                         Projections.constructor(
@@ -150,8 +152,31 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .from(popup)
                 .where(popup.id.in(popupIds))
                 .orderBy(popup.id.asc())
-                .limit(4)
+                .limit(limit)
                 .fetch();
+    }
+
+    @Override
+    public List<PopupInfoResponse> findRandomPopups(List<Long> excludeIds, int size) {
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                PopupInfoResponse.class,
+                                popup.id,
+                                popup.name,
+                                popup.imageUrl,
+                                popup.popupStartDate.stringValue(),
+                                popup.popupEndDate.stringValue(),
+                                getFullAddress()))
+                .from(popup)
+                .where(popup.id.notIn(excludeIds))
+                .orderBy(randomOrder())
+                .limit(size)
+                .fetch();
+    }
+
+    private OrderSpecifier<Double> randomOrder() {
+        return Expressions.numberTemplate(Double.class, "function('rand')").asc();
     }
 
     private BooleanExpression checkPopupSearchName(String keyword) {

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -126,7 +126,23 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     public List<PopupInfoResponse> findPopupsByIds(PopupIdsRequest request) {
-        return popupRepository.findPopupsByIds(request.popupIds());
+        final int requestSize = request.popupIds().size();
+        final int targetSize = 4;
+
+        if (requestSize >= targetSize) {
+            return popupRepository.findPopupsByIds(request.popupIds(), targetSize);
+        } else {
+            List<PopupInfoResponse> requestedPopups =
+                    popupRepository.findPopupsByIds(request.popupIds(), targetSize);
+            int additionalCount = targetSize - requestSize;
+            List<PopupInfoResponse> randomPopups =
+                    popupRepository.findRandomPopups(request.popupIds(), additionalCount);
+
+            List<PopupInfoResponse> results = new ArrayList<>(requestedPopups);
+            results.addAll(randomPopups);
+
+            return results;
+        }
     }
 
     private Popup createPopupFromRequest(Manager manager, PopupCreateRequest popupCreateRequest) {

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -384,35 +384,17 @@ public class PopupServiceTest extends IntegrationTest {
 
         @Test
         @Transactional
-        void 정상적으로_리스트_조회에_성공한다() {
-            // given
-            Long popupId1 = createPopup();
-            Long popupId2 = createPopup();
-            Long popupId3 = createPopup();
-            Long popupId4 = createPopup();
-            PopupIdsRequest request =
-                    new PopupIdsRequest(List.of(popupId1, popupId2, popupId3, popupId4));
-
-            // when
-            List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
-
-            // then
-            assertThat(results).hasSize(4);
-            List<Long> resultIds = results.stream().map(PopupInfoResponse::popupId).toList();
-            assertThat(resultIds).containsExactlyInAnyOrder(popupId1, popupId2, popupId3, popupId4);
-        }
-
-        @Test
-        @Transactional
-        void 팝업_아이디_리스트의_크기가_4보다_큰_경우에도_4개의_팝업_정보_리스트만_반환한다() {
+        void 요청된_아이디가_4개보다_많은_경우_정확히_4개만_반환한다() {
             // given
             Long popupId1 = createPopup();
             Long popupId2 = createPopup();
             Long popupId3 = createPopup();
             Long popupId4 = createPopup();
             Long popupId5 = createPopup();
+            Long popupId6 = createPopup();
             PopupIdsRequest request =
-                    new PopupIdsRequest(List.of(popupId1, popupId2, popupId3, popupId4, popupId5));
+                    new PopupIdsRequest(
+                            List.of(popupId1, popupId2, popupId3, popupId4, popupId5, popupId6));
 
             // when
             List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
@@ -425,19 +407,55 @@ public class PopupServiceTest extends IntegrationTest {
 
         @Test
         @Transactional
-        void 팝업_아이디_리스트의_크기가_4보다_작은_경우에도_해당_크기의_팝업_정보_리스트를_반환한다() {
+        void 요청된_아이디가_4개보다_적은_경우_부족한_개수만큼_랜덤으로_채워서_4개를_반환한다() {
             // given
             Long popupId1 = createPopup();
             Long popupId2 = createPopup();
-            PopupIdsRequest request = new PopupIdsRequest(List.of(popupId1, popupId2));
+            Long popupId3 = createPopup(); // 요청 ID
+            Long popupId4 = createPopup(); // 요청 ID
+            Long popupId5 = createPopup();
+            Long popupId6 = createPopup();
+            Long popupId7 = createPopup();
+            PopupIdsRequest request = new PopupIdsRequest(List.of(popupId3, popupId4));
 
             // when
             List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
 
             // then
-            assertThat(results).hasSize(2);
+            assertThat(results).hasSize(4);
+
             List<Long> resultIds = results.stream().map(PopupInfoResponse::popupId).toList();
-            assertThat(resultIds).containsExactlyInAnyOrder(popupId1, popupId2);
+
+            assertThat(resultIds).contains(popupId3, popupId4);
+
+            List<Long> otherPopupIds = List.of(popupId1, popupId2, popupId5, popupId6, popupId7);
+            List<Long> additionalIds =
+                    resultIds.stream()
+                            .filter(id -> !List.of(popupId3, popupId4).contains(id))
+                            .toList();
+
+            assertThat(additionalIds).hasSize(2);
+            assertThat(otherPopupIds).containsAll(additionalIds);
+        }
+
+        @Test
+        @Transactional
+        void 전체_팝업이_4개_미만인_경우_존재하는_모든_팝업을_반환한다() {
+            // given
+            Long popupId1 = createPopup();
+            Long popupId2 = createPopup();
+            Long popupId3 = createPopup();
+
+            PopupIdsRequest request = new PopupIdsRequest(List.of(popupId1));
+
+            // when
+            List<PopupInfoResponse> results = popupService.findPopupsByIds(request);
+
+            // then
+            assertThat(results).hasSize(3);
+
+            List<Long> resultIds = results.stream().map(PopupInfoResponse::popupId).toList();
+            assertThat(resultIds).containsExactlyInAnyOrder(popupId1, popupId2, popupId3);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-259]

---
## 📌 작업 내용 및 특이사항

### 기존 동작
+ 요청된 팝업 ID 개수만큼 팝업 정보를 반환했습니다.
+ 빈 리스트 요청 시 빈 리스트 반환했습니다

### 수정된 동작
+ 요청 팝업 ID의 개수가 4개 이상인 경우 기존 로직과 동일하게 동작합니다.
+ 요청 팝업 ID의 개수가 4개 미만인 경우에 부족한 개수만큼 랜덤한 팝업 아이디를 추가하여 4개를 채웁니다.
+ 요청된 팝업 ID의 중복을 방지하기 위해 기존 요청을 제외하는 쿼리를 추가했습니다.
+ DB에 저장된 팝업 자체가 4개 미만인 경우 해당 개수 만큼 반환됩니다. ex) DB에 3개의 팝업만 존재하는 경우 크기가 3인 리스트로 반환합니다.
+ 인기순으로 정렬된 팝업 아이디 리스트의 순서를 유지하기 위해 CASE WHEN 구문을 활용한 쿼리를 작성했습니다.

---
## 📚 참고사항

-


[LCR-259]: https://lgcns-retail.atlassian.net/browse/LCR-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ