### PR TITLE
refactor: Entrance 테이블 age 속성 Enum 타입으로 변경

### DIFF
--- a/src/main/java/com/lgcns/domain/entrance/domain/Entrance.java
+++ b/src/main/java/com/lgcns/domain/entrance/domain/Entrance.java
@@ -23,7 +23,8 @@ public class Entrance {
     @Enumerated(EnumType.STRING)
     private MemberGender gender;
 
-    private int ageGroup;
+    @Enumerated(EnumType.STRING)
+    private MemberAge age;
 
     private LocalDate reservationDate;
 
@@ -33,12 +34,12 @@ public class Entrance {
     private Entrance(
             Long popupId,
             MemberGender gender,
-            int ageGroup,
+            MemberAge age,
             LocalDate reservationDate,
             LocalTime reservationTime) {
         this.popupId = popupId;
         this.gender = gender;
-        this.ageGroup = ageGroup;
+        this.age = age;
         this.reservationDate = reservationDate;
         this.reservationTime = reservationTime;
     }
@@ -46,13 +47,13 @@ public class Entrance {
     public static Entrance createPopupEnter(
             Long popupId,
             MemberGender gender,
-            int ageGroup,
+            MemberAge age,
             LocalDate reservationDate,
             LocalTime reservationTime) {
         return Entrance.builder()
                 .popupId(popupId)
                 .gender(gender)
-                .ageGroup(ageGroup)
+                .age(age)
                 .reservationDate(reservationDate)
                 .reservationTime(reservationTime)
                 .build();

--- a/src/main/java/com/lgcns/domain/entrance/domain/MemberAge.java
+++ b/src/main/java/com/lgcns/domain/entrance/domain/MemberAge.java
@@ -1,0 +1,16 @@
+package com.lgcns.domain.entrance.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberAge {
+    TEENAGER("10대"),
+    TWENTIES("20대"),
+    THIRTIES("30대"),
+    FORTIES_AND_ABOVE("40대 이상"),
+    ;
+
+    private final String age;
+}

--- a/src/main/java/com/lgcns/domain/entrance/dto/request/EntranceCreateRequest.java
+++ b/src/main/java/com/lgcns/domain/entrance/dto/request/EntranceCreateRequest.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.entrance.dto.request;
 
+import com.lgcns.domain.entrance.domain.MemberAge;
 import com.lgcns.domain.entrance.domain.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -12,7 +13,7 @@ public record EntranceCreateRequest(
         @NotNull(message = "방문자 성별은 필수입니다.") @Schema(description = "방문자 성별", example = "FEMALE")
                 MemberGender gender,
         @NotNull(message = "방문자 나이대는 필수입니다.") @Schema(description = "방문자 나이대", example = "20")
-                Integer ageGroup,
+                MemberAge age,
         @NotNull(message = "예약 날짜는 필수입니다.")
                 @Schema(description = "팝업 예약 날짜", example = "2025-05-13")
                 LocalDate reservationDate,
@@ -21,10 +22,9 @@ public record EntranceCreateRequest(
     public static EntranceCreateRequest of(
             Long popupId,
             MemberGender gender,
-            Integer ageGroup,
+            MemberAge age,
             LocalDate reservationDate,
             LocalTime reservationTime) {
-        return new EntranceCreateRequest(
-                popupId, gender, ageGroup, reservationDate, reservationTime);
+        return new EntranceCreateRequest(popupId, gender, age, reservationDate, reservationTime);
     }
 }

--- a/src/main/java/com/lgcns/domain/entrance/service/EntranceServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/entrance/service/EntranceServiceImpl.java
@@ -30,7 +30,7 @@ public class EntranceServiceImpl implements EntranceService {
                 Entrance.createPopupEnter(
                         request.popupId(),
                         request.gender(),
-                        request.ageGroup(),
+                        request.age(),
                         request.reservationDate(),
                         request.reservationTime());
 

--- a/src/main/java/com/lgcns/domain/survey/domain/MemberAnswer.java
+++ b/src/main/java/com/lgcns/domain/survey/domain/MemberAnswer.java
@@ -23,14 +23,9 @@ public class MemberAnswer extends BaseTimeEntity {
 
     private int answerNumber;
 
-    private String memberGender;
-    private int memberAge;
-
     @Builder
-    private MemberAnswer(Survey survey, int answerNumber, String memberGender, int memberAge) {
+    private MemberAnswer(Survey survey, int answerNumber) {
         this.survey = survey;
         this.answerNumber = answerNumber;
-        this.memberGender = memberGender;
-        this.memberAge = memberAge;
     }
 }

--- a/src/main/resources/db/migration/V21__alter_entrance_table_age.sql
+++ b/src/main/resources/db/migration/V21__alter_entrance_table_age.sql
@@ -1,0 +1,10 @@
+ALTER TABLE entrance
+DROP COLUMN age_group;
+
+ALTER TABLE entrance
+ADD COLUMN age VARCHAR(20) NOT NULL;
+
+UPDATE entrance SET age = '20대' WHERE entrance_id IN (1, 6, 9, 12, 15, 20, 22, 25, 30);
+UPDATE entrance SET age = '30대' WHERE entrance_id IN (2, 5, 10, 13, 18, 23, 26, 29);
+UPDATE entrance SET age = '10대' WHERE entrance_id IN (3, 8, 14, 17, 21, 28);
+UPDATE entrance SET age = '40대 이상' WHERE entrance_id IN (4, 7, 11, 16, 19, 24, 27);

--- a/src/main/resources/db/migration/V22__alter_member_answer_drop_gender_and_age_column.sql
+++ b/src/main/resources/db/migration/V22__alter_member_answer_drop_gender_and_age_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member_answer DROP COLUMN member_age;
+ALTER TABLE member_answer DROP COLUMN member_gender;

--- a/src/test/java/com/lgcns/domain/entrance/service/EntranceServiceTest.java
+++ b/src/test/java/com/lgcns/domain/entrance/service/EntranceServiceTest.java
@@ -91,7 +91,7 @@ class EntranceServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(savedEntrance.getPopupId()).isEqualTo(1L),
                     () -> assertThat(savedEntrance.getGender()).isEqualTo(MemberGender.MALE),
-                    () -> assertThat(savedEntrance.getAge()).isEqualTo(20),
+                    () -> assertThat(savedEntrance.getAge()).isEqualTo(MemberAge.TWENTIES),
                     () ->
                             assertThat(savedEntrance.getReservationDate())
                                     .isEqualTo(LocalDate.parse("2025-05-13")),

--- a/src/test/java/com/lgcns/domain/entrance/service/EntranceServiceTest.java
+++ b/src/test/java/com/lgcns/domain/entrance/service/EntranceServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.entrance.domain.Entrance;
+import com.lgcns.domain.entrance.domain.MemberAge;
 import com.lgcns.domain.entrance.domain.MemberGender;
 import com.lgcns.domain.entrance.dto.request.EntranceCreateRequest;
 import com.lgcns.domain.entrance.dto.response.DailyEntrantCountResponse;
@@ -75,12 +76,12 @@ class EntranceServiceTest extends IntegrationTest {
             // given
             Long popupId = 1L;
             MemberGender gender = MemberGender.MALE;
-            int ageGroup = 20;
+            MemberAge age = MemberAge.TWENTIES;
             LocalDate date = LocalDate.parse("2025-05-13");
             LocalTime time = LocalTime.parse("10:00:00");
 
             EntranceCreateRequest request =
-                    new EntranceCreateRequest(popupId, gender, ageGroup, date, time);
+                    new EntranceCreateRequest(popupId, gender, age, date, time);
 
             // when
             entranceService.createEntrance(request);
@@ -90,7 +91,7 @@ class EntranceServiceTest extends IntegrationTest {
             Assertions.assertAll(
                     () -> assertThat(savedEntrance.getPopupId()).isEqualTo(1L),
                     () -> assertThat(savedEntrance.getGender()).isEqualTo(MemberGender.MALE),
-                    () -> assertThat(savedEntrance.getAgeGroup()).isEqualTo(20),
+                    () -> assertThat(savedEntrance.getAge()).isEqualTo(20),
                     () ->
                             assertThat(savedEntrance.getReservationDate())
                                     .isEqualTo(LocalDate.parse("2025-05-13")),
@@ -123,35 +124,35 @@ class EntranceServiceTest extends IntegrationTest {
                     Entrance.createPopupEnter(
                             popupId,
                             MemberGender.MALE,
-                            20,
+                            MemberAge.TWENTIES,
                             LocalDate.now(),
                             LocalTime.parse("10:00:00")));
             entranceRepository.save(
                     Entrance.createPopupEnter(
                             popupId,
                             MemberGender.MALE,
-                            20,
+                            MemberAge.TWENTIES,
                             LocalDate.now(),
                             LocalTime.parse("10:00:00")));
             entranceRepository.save(
                     Entrance.createPopupEnter(
                             popupId,
                             MemberGender.MALE,
-                            20,
+                            MemberAge.TWENTIES,
                             LocalDate.now(),
                             LocalTime.parse("10:00:00")));
             entranceRepository.save(
                     Entrance.createPopupEnter(
                             popupId,
                             MemberGender.MALE,
-                            20,
+                            MemberAge.TWENTIES,
                             LocalDate.now(),
                             LocalTime.parse("10:00:00")));
             entranceRepository.save(
                     Entrance.createPopupEnter(
                             popupId,
                             MemberGender.MALE,
-                            20,
+                            MemberAge.TWENTIES,
                             LocalDate.now(),
                             LocalTime.parse("10:00:00")));
 

--- a/src/test/java/com/lgcns/domain/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/lgcns/domain/survey/service/SurveyServiceTest.java
@@ -163,13 +163,7 @@ public class SurveyServiceTest extends IntegrationTest {
         // 1명의 사용자 응답 (Survey 4개에 대해 각 1개씩 응답)
         for (Survey survey : surveys) {
             // 예: 선택 번호는 무조건 1번으로 고정 (또는 랜덤 가능)
-            MemberAnswer answer =
-                    MemberAnswer.builder()
-                            .survey(survey)
-                            .answerNumber(1)
-                            .memberGender("MALE")
-                            .memberAge(25)
-                            .build();
+            MemberAnswer answer = MemberAnswer.builder().survey(survey).answerNumber(1).build();
             memberAnswerRepository.save(answer);
         }
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-264]

---
## 📌 작업 내용 및 특이사항

- 기존 int 로 돼있던 age column을 MemberAge enum으로 변경했습니다.
- MemberAnser에 있던 memberGener, memberAge를 삭제했습니다. (성별, 나이 필터링 제거에 따른 수정)

[LCR-264]: https://lgcns-retail.atlassian.net/browse/LCR-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ