### PR TITLE
fix: Internal 인기 팝업 리스트 조회 에러 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -126,8 +126,13 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     public List<PopupInfoResponse> findPopupsByIds(PopupIdsRequest request) {
-        final int requestSize = request.popupIds().size();
+
         final int targetSize = 4;
+        final int requestSize = request.popupIds().size();
+
+        if (request.popupIds().isEmpty()) {
+            return popupRepository.findRandomPopups(request.popupIds(), targetSize);
+        }
 
         if (requestSize >= targetSize) {
             return popupRepository.findPopupsByIds(request.popupIds(), targetSize);


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-273]

---
## 📌 작업 내용 및 특이사항

- 인기 팝업 아이디 리스트가 비어있는 경우 (member_reservation 테이블에 데이터 x ) 발생하는 500 에러 해결했습니다
- 이 경우, 서비스 레이어에서 빈 리스트 검사를 통해 바로 랜덤한 팝업을 조회하여 반환하도록 분기처리 했습니다.

---
## 📚 참고사항

-


[LCR-273]: https://lgcns-retail.atlassian.net/browse/LCR-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ