### PR TITLE
refactor: Entrance 테이블 age 속성 Enum 타입으로 변경

### DIFF
--- a/src/main/java/com/lgcns/domain/entrance/dto/request/EntranceCreateRequest.java
+++ b/src/main/java/com/lgcns/domain/entrance/dto/request/EntranceCreateRequest.java
@@ -4,8 +4,7 @@ import com.lgcns.domain.entrance.domain.MemberAge;
 import com.lgcns.domain.entrance.domain.MemberGender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import jakarta.validation.constraints.Pattern;
 
 public record EntranceCreateRequest(
         @NotNull(message = "팝업 ID는 필수입니다.") @Schema(description = "팝업 ID", example = "1")
@@ -16,15 +15,18 @@ public record EntranceCreateRequest(
                 MemberAge age,
         @NotNull(message = "예약 날짜는 필수입니다.")
                 @Schema(description = "팝업 예약 날짜", example = "2025-05-13")
-                LocalDate reservationDate,
-        @NotNull(message = "예약 시간은 필수입니다.") @Schema(description = "팝업 예약 시간", example = "10:00:00")
-                LocalTime reservationTime) {
+                @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 yyyy-MM-dd이어야 합니다.")
+                String reservationDate,
+        @NotNull(message = "예약 시간은 필수입니다.")
+                @Schema(description = "팝업 예약 시간", example = "10:00:00")
+                @Pattern(regexp = "^\\d{2}:\\d{2}:\\d{2}$", message = "시간 형식은 HH:mm:ss이어야 합니다.")
+                String reservationTime) {
     public static EntranceCreateRequest of(
             Long popupId,
             MemberGender gender,
             MemberAge age,
-            LocalDate reservationDate,
-            LocalTime reservationTime) {
+            String reservationDate,
+            String reservationTime) {
         return new EntranceCreateRequest(popupId, gender, age, reservationDate, reservationTime);
     }
 }

--- a/src/main/java/com/lgcns/domain/entrance/service/EntranceServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/entrance/service/EntranceServiceImpl.java
@@ -11,6 +11,7 @@ import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,8 +32,8 @@ public class EntranceServiceImpl implements EntranceService {
                         request.popupId(),
                         request.gender(),
                         request.age(),
-                        request.reservationDate(),
-                        request.reservationTime());
+                        LocalDate.parse(request.reservationDate()),
+                        LocalTime.parse(request.reservationTime()));
 
         entranceRepository.save(entrance);
     }

--- a/src/main/java/com/lgcns/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/lgcns/global/common/constants/UrlConstants.java
@@ -3,6 +3,7 @@ package com.lgcns.global.common.constants;
 public final class UrlConstants {
     public static final String DEV_CLIENT_URL = "https://www.dev.ceo.popi.today";
     public static final String LOCAL_CLIENT_URL = "http://localhost:3000";
+    public static final String LOCAL_TEST_URL = "- http://localhost:4173";
 
     public static final String DEV_SERVER_URL = "https://dev-api.ceo.popi.today";
     public static final String LOCAL_SERVER_URL = "http://localhost:8080";

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -104,6 +104,7 @@ public class WebSecurityConfig {
             configuration.addAllowedOriginPattern(DEV_SERVER_URL);
             configuration.addAllowedOriginPattern(DEV_CLIENT_URL);
             configuration.addAllowedOriginPattern(LOCAL_CLIENT_URL);
+            configuration.addAllowedOriginPattern(LOCAL_TEST_URL);
         }
 
         configuration.addAllowedHeader("*");

--- a/src/test/java/com/lgcns/domain/entrance/service/EntranceServiceTest.java
+++ b/src/test/java/com/lgcns/domain/entrance/service/EntranceServiceTest.java
@@ -77,8 +77,8 @@ class EntranceServiceTest extends IntegrationTest {
             Long popupId = 1L;
             MemberGender gender = MemberGender.MALE;
             MemberAge age = MemberAge.TWENTIES;
-            LocalDate date = LocalDate.parse("2025-05-13");
-            LocalTime time = LocalTime.parse("10:00:00");
+            String date = LocalDate.parse("2025-05-13").toString();
+            String time = LocalTime.parse("10:00:00").toString();
 
             EntranceCreateRequest request =
                     new EntranceCreateRequest(popupId, gender, age, date, time);


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-264]

---
## 📌 작업 내용 및 특이사항

- Entrance 테이블 age 속성 Enum 타입으로 변경했습니다.
-  MemberAge enum 적용 flyway script 작성했습니다.
- EntranceCreateRequest 내 date, time String type으로 변경했습니다.

[LCR-264]: https://lgcns-retail.atlassian.net/browse/LCR-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ