### PR TITLE
chore: Kafka 메시지 수신을 위한 Consumer 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,10 @@ dependencies {
 
     // WireMock
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:4.2.1'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,0 +1,29 @@
+services:
+  kafka:
+    container_name: kafka
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
+      KAFKA_LISTENERS: 'CONTROLLER://kafka:29093,PLAINTEXT://kafka:9092,PLAINTEXT_HOST://0.0.0.0:29092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      CLUSTER_ID: 'ciWo7IWazngRchmPES6q5A=='
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+  kafka-ui:
+    container_name: kafka-ui
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8989:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAP SERVERS: kafka:9092
+    depends_on:
+      - kafka

--- a/src/main/java/com/lgcns/global/common/constants/UrlConstants.java
+++ b/src/main/java/com/lgcns/global/common/constants/UrlConstants.java
@@ -3,7 +3,7 @@ package com.lgcns.global.common.constants;
 public final class UrlConstants {
     public static final String DEV_CLIENT_URL = "https://www.dev.ceo.popi.today";
     public static final String LOCAL_CLIENT_URL = "http://localhost:3000";
-    public static final String LOCAL_TEST_URL = "- http://localhost:4173";
+    public static final String LOCAL_TEST_URL = "http://localhost:4173";
 
     public static final String DEV_SERVER_URL = "https://dev-api.ceo.popi.today";
     public static final String LOCAL_SERVER_URL = "http://localhost:8080";

--- a/src/main/java/com/lgcns/global/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/lgcns/global/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,42 @@
+package com.lgcns.global.config.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        kafkaListenerContainerFactory.setConsumerFactory(consumerFactory());
+
+        return kafkaListenerContainerFactory;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,7 +14,7 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092
 
 eureka:
   instance:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+  kafka:
+    bootstrap-servers: localhost:9092
 
 eureka:
   instance:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=MYSQL
   flyway:
     enabled: false
+  kafka:
+    bootstrap-servers: localhost:9092
 
 reservation:
   service:


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-275]

---
## 📌 작업 내용 및 특이사항

- 매니저 서비스에서 Kafka 메시지를 수신할 수 있도록 Consumer 설정을 추가했습니다.
- 현재는 토픽 구독과 메시지 역직렬화 기반의 기본 구조만 구성되어 있으며, 실제 비즈니스 로직은 이후 진행해주시면 됩니다.
- 로컬 Kafka 실행용 docker-compose-kafka.yml을 추가하였습니다.

## 📚 참고사항
- Kafka 메시지 소비 로직은 각 도메인 패키지 내부에 위치시키며, 아래처럼 @KafkaListener를 활용해 도메인 책임에 따라 처리하도록 구현해 주세요.
<img width="873" alt="image" src="https://github.com/user-attachments/assets/0fe2aae3-0623-4b8d-9424-79aedfe9b2d6" />


[LCR-275]: https://lgcns-retail.atlassian.net/browse/LCR-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ