### PR TITLE
feat: Internal 지도 기반 팝업 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -40,6 +40,16 @@ public class PopupInternalController {
         return popupService.findPopupsByNameWithPagination(keyword, lastPopupId, size);
     }
 
+    @GetMapping("/popups/map")
+    @Operation(summary = "지도 기반 팝업 조회", description = "요청된 범위 내의 존재하는 모든 팝업을 조회합니다.")
+    public List<PopupInfoResponse> findPopupsByMapArea(
+            @RequestParam Double latMin,
+            @RequestParam Double latMax,
+            @RequestParam Double lngMin,
+            @RequestParam Double lngMax) {
+        return popupService.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
+    }
+
     @GetMapping("/popups/{popupId}")
     @Operation(summary = "팝업 상세 조회", description = "팝업 ID를 통해 해당 팝업의 상세 정보를 조회합니다.")
     public PopupDetailsResponse popupDetailsFind(@PathVariable Long popupId) {

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -13,6 +13,9 @@ public interface PopupRepositoryCustom {
     Slice<PopupInfoResponse> findPopupsByNameWithPagination(
             String keyword, Long lastPopupId, int size);
 
+    List<PopupInfoResponse> findPopupsByMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax);
+
     PopupDetailsResponse findPopupDetailsById(Long popupId);
 
     List<PopupDetailsResponse> findReservedPopupInfo(List<Long> popupIds);

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -178,6 +178,34 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<PopupInfoResponse> findPopupsByMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax) {
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                PopupInfoResponse.class,
+                                popup.id,
+                                popup.name,
+                                popup.imageUrl,
+                                popup.popupStartDate.stringValue(),
+                                popup.popupEndDate.stringValue(),
+                                getFullAddress()))
+                .from(popup)
+                .where(
+                        popup.popupEndDate.goe(LocalDate.now()),
+                        isWithinMapArea(latMin, latMax, lngMin, lngMax))
+                .fetch();
+    }
+
+    private BooleanExpression isWithinMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax) {
+        return popup.address
+                .latitude
+                .between(latMin, latMax)
+                .and(popup.address.longitude.between(lngMin, lngMax));
+    }
+
     private NumberExpression<Integer> createOrderByPopupIds(List<Long> popupIds) {
         String caseWhenClause =
                 IntStream.range(0, popupIds.size())

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -11,6 +11,9 @@ public interface PopupService {
 
     List<PopupPreviewResponse> findAllPopups();
 
+    List<PopupInfoResponse> findPopupsByMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax);
+
     void deletePopup(Long popupId);
 
     List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId);

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -93,6 +93,13 @@ public class PopupServiceImpl implements PopupService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<PopupInfoResponse> findPopupsByMapArea(
+            Double latMin, Double latMax, Double lngMin, Double lngMax) {
+        return popupRepository.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
+    }
+
+    @Override
     public List<SurveyChoiceResponse> findAllChoicesByPopupId(Long popupId) {
 
         List<ChoiceInfoResponse> choiceInfoList = popupRepository.findAllChoices(popupId);

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -459,6 +459,113 @@ public class PopupServiceTest extends IntegrationTest {
         }
     }
 
+    @Nested
+    class 지도_기반_팝업_리스트를_조회할_때 {
+
+        @Test
+        @Transactional
+        void 지정된_범위_내에_팝업이_존재할_때_해당_팝업들을_반환한다() {
+            // given
+            // 서울 전제에 해당하는 위,경도 범위
+            Double latMin = 37.378638;
+            Double latMax = 37.671877;
+            Double lngMin = 126.7995439;
+            Double lngMax = 127.184881;
+
+            Long popupId1 =
+                    createPopupWithAllParams(
+                            "강남 BLACKPINK 팝업스토어",
+                            "https://bucket/blackpink.jpg",
+                            LocalDate.of(2025, 5, 1),
+                            LocalDate.of(2025, 6, 1),
+                            LocalDateTime.of(2025, 4, 25, 10, 0),
+                            LocalDateTime.of(2025, 5, 31, 23, 59),
+                            LocalTime.of(10, 0),
+                            LocalTime.of(18, 0),
+                            100,
+                            10,
+                            "서울특별시 강남구 테헤란로 123",
+                            "3층",
+                            37.5,
+                            127.0,
+                            createDefaultChoices());
+
+            Long popupId2 =
+                    createPopupWithAllParams(
+                            "홍대 BTS 팝업스토어",
+                            "https://bucket/bts.jpg",
+                            LocalDate.of(2025, 5, 15),
+                            LocalDate.of(2025, 6, 15),
+                            LocalDateTime.of(2025, 5, 10, 10, 0),
+                            LocalDateTime.of(2025, 6, 14, 23, 59),
+                            LocalTime.of(11, 0),
+                            LocalTime.of(19, 0),
+                            80,
+                            8,
+                            "서울특별시 마포구 홍익로 456",
+                            "2층",
+                            37.55,
+                            126.92,
+                            createDefaultChoices());
+
+            // when
+            List<PopupInfoResponse> result =
+                    popupService.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(result.get(0).popupName()).isEqualTo("강남 BLACKPINK 팝업스토어"),
+                    () ->
+                            assertThat(result.get(0).imageUrl())
+                                    .isEqualTo("https://bucket/blackpink.jpg"),
+                    () -> assertThat(result.get(0).popupOpenDate()).isEqualTo("2025-05-01"),
+                    () -> assertThat(result.get(0).popupCloseDate()).isEqualTo("2025-06-01"),
+                    () -> assertThat(result.get(0).address()).isEqualTo("서울특별시 강남구 테헤란로 123, 3층"),
+                    () -> assertThat(result.get(1).popupName()).isEqualTo("홍대 BTS 팝업스토어"),
+                    () -> assertThat(result.get(1).imageUrl()).isEqualTo("https://bucket/bts.jpg"),
+                    () -> assertThat(result.get(1).popupOpenDate()).isEqualTo("2025-05-15"),
+                    () -> assertThat(result.get(1).popupCloseDate()).isEqualTo("2025-06-15"),
+                    () -> assertThat(result.get(1).address()).isEqualTo("서울특별시 마포구 홍익로 456, 2층"));
+        }
+
+        @Test
+        @Transactional
+        void 지정된_범위_내에_팝업이_존재하지_않으면_빈_리스트를_반환한다() {
+            // given
+            Long popupId1 =
+                    createPopupWithAllParams(
+                            "부산 팝업스토어",
+                            "https://bucket/busan.jpg",
+                            LocalDate.of(2025, 5, 1),
+                            LocalDate.of(2025, 6, 1),
+                            LocalDateTime.of(2025, 4, 25, 10, 0),
+                            LocalDateTime.of(2025, 5, 31, 23, 59),
+                            LocalTime.of(10, 0),
+                            LocalTime.of(18, 0),
+                            100,
+                            10,
+                            "부산광역시 해운대구",
+                            "1층",
+                            35.1,
+                            129.0,
+                            createDefaultChoices());
+
+            // 서울
+            Double latMin = 37.378638;
+            Double latMax = 37.671877;
+            Double lngMin = 126.7995439;
+            Double lngMax = 127.184881;
+
+            // when
+            List<PopupInfoResponse> result =
+                    popupService.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
     private Long createPopupWithAllParams(
             String name,
             String imageUrl,

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -469,7 +469,7 @@ public class PopupServiceTest extends IntegrationTest {
             // 서울 전제에 해당하는 위,경도 범위
             Double latMin = 37.378638;
             Double latMax = 37.671877;
-            Double lngMin = 126.7995439;
+            Double lngMin = 126.799543;
             Double lngMax = 127.184881;
 
             Long popupId1 =
@@ -554,7 +554,7 @@ public class PopupServiceTest extends IntegrationTest {
             // 서울
             Double latMin = 37.378638;
             Double latMax = 37.671877;
-            Double lngMin = 126.7995439;
+            Double lngMin = 126.799543;
             Double lngMax = 127.184881;
 
             // when


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-234]

---
## 📌 작업 내용 및 특이사항

- 지도의 현재 범위 (위도, 경도) 값을 feign client로부터 받아 예약 가능한 팝업 중 지도 내에 위치한 팝업들을 리스트로 반환하는 기능을 구현했습니다.
- 지도의 현재 범위는 각각 위도와 경도로 이루어진 좌하단 지점과 우상단 지점의 값으로 판단합니다.
- 지도 범위 내에 존재하는 팝업이 없는 경우 빈 리스트를 반환하므로 별도의 예외처리는 하지 않았습니다.

---
## 📚 참고사항

-


[LCR-234]: https://lgcns-retail.atlassian.net/browse/LCR-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ