### PR TITLE
fix: Internal 지도 기반 팝업 리스트 조회 응답 DTO 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/popup/dto/response/PopupMapResponse.java
+++ b/src/main/java/com/lgcns/domain/popup/dto/response/PopupMapResponse.java
@@ -1,0 +1,31 @@
+package com.lgcns.domain.popup.dto.response;
+
+public record PopupMapResponse(
+        Long popupId,
+        String popupName,
+        String imageUrl,
+        String popupOpenDate,
+        String popupCloseDate,
+        String address,
+        Double latitude,
+        Double longitude) {
+    public static PopupMapResponse of(
+            Long popupId,
+            String popupName,
+            String imageUrl,
+            String popupOpenDate,
+            String popupCloseDate,
+            String address,
+            Double latitude,
+            Double longitude) {
+        return new PopupMapResponse(
+                popupId,
+                popupName,
+                imageUrl,
+                popupOpenDate,
+                popupCloseDate,
+                address,
+                latitude,
+                longitude);
+    }
+}

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -3,6 +3,7 @@ package com.lgcns.domain.popup.internalApi;
 import com.lgcns.domain.popup.dto.request.PopupIdsRequest;
 import com.lgcns.domain.popup.dto.response.PopupDetailsResponse;
 import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
+import com.lgcns.domain.popup.dto.response.PopupMapResponse;
 import com.lgcns.domain.popup.dto.response.SurveyChoiceResponse;
 import com.lgcns.domain.popup.service.PopupService;
 import com.lgcns.global.common.response.SliceResponse;
@@ -42,7 +43,7 @@ public class PopupInternalController {
 
     @GetMapping("/popups/map")
     @Operation(summary = "지도 기반 팝업 조회", description = "요청된 범위 내의 존재하는 모든 팝업을 조회합니다.")
-    public List<PopupInfoResponse> findPopupsByMapArea(
+    public List<PopupMapResponse> findPopupsByMapArea(
             @RequestParam Double latMin,
             @RequestParam Double latMax,
             @RequestParam Double lngMin,

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface PopupRepositoryCustom {
     Slice<PopupInfoResponse> findPopupsByNameWithPagination(
             String keyword, Long lastPopupId, int size);
 
-    List<PopupInfoResponse> findPopupsByMapArea(
+    List<PopupMapResponse> findPopupsByMapArea(
             Double latMin, Double latMax, Double lngMin, Double lngMax);
 
     PopupDetailsResponse findPopupDetailsById(Long popupId);

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepositoryImpl.java
@@ -4,10 +4,7 @@ import static com.lgcns.domain.popup.domain.QPopup.popup;
 import static com.lgcns.domain.survey.domain.QChoice.choice;
 import static com.lgcns.domain.survey.domain.QSurvey.survey;
 
-import com.lgcns.domain.popup.dto.response.ChoiceInfoResponse;
-import com.lgcns.domain.popup.dto.response.PopupDetailsResponse;
-import com.lgcns.domain.popup.dto.response.PopupInfoResponse;
-import com.lgcns.domain.popup.dto.response.PopupPreviewResponse;
+import com.lgcns.domain.popup.dto.response.*;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.global.error.exception.CustomException;
 import com.querydsl.core.types.OrderSpecifier;
@@ -179,18 +176,20 @@ public class PopupRepositoryImpl implements PopupRepositoryCustom {
     }
 
     @Override
-    public List<PopupInfoResponse> findPopupsByMapArea(
+    public List<PopupMapResponse> findPopupsByMapArea(
             Double latMin, Double latMax, Double lngMin, Double lngMax) {
         return jpaQueryFactory
                 .select(
                         Projections.constructor(
-                                PopupInfoResponse.class,
+                                PopupMapResponse.class,
                                 popup.id,
                                 popup.name,
                                 popup.imageUrl,
                                 popup.popupStartDate.stringValue(),
                                 popup.popupEndDate.stringValue(),
-                                getFullAddress()))
+                                getFullAddress(),
+                                popup.address.latitude,
+                                popup.address.longitude))
                 .from(popup)
                 .where(
                         popup.popupEndDate.goe(LocalDate.now()),

--- a/src/main/java/com/lgcns/domain/popup/service/PopupService.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupService.java
@@ -11,7 +11,7 @@ public interface PopupService {
 
     List<PopupPreviewResponse> findAllPopups();
 
-    List<PopupInfoResponse> findPopupsByMapArea(
+    List<PopupMapResponse> findPopupsByMapArea(
             Double latMin, Double latMax, Double lngMin, Double lngMax);
 
     void deletePopup(Long popupId);

--- a/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/popup/service/PopupServiceImpl.java
@@ -94,7 +94,7 @@ public class PopupServiceImpl implements PopupService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PopupInfoResponse> findPopupsByMapArea(
+    public List<PopupMapResponse> findPopupsByMapArea(
             Double latMin, Double latMax, Double lngMin, Double lngMax) {
         return popupRepository.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
     }

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -509,7 +509,7 @@ public class PopupServiceTest extends IntegrationTest {
                             createDefaultChoices());
 
             // when
-            List<PopupInfoResponse> result =
+            List<PopupMapResponse> result =
                     popupService.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
 
             // then
@@ -558,7 +558,7 @@ public class PopupServiceTest extends IntegrationTest {
             Double lngMax = 127.184881;
 
             // when
-            List<PopupInfoResponse> result =
+            List<PopupMapResponse> result =
                     popupService.findPopupsByMapArea(latMin, latMax, lngMin, lngMax);
 
             // then


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-286]

---
## 📌 작업 내용 및 특이사항

- 기존의 반환값에 위도, 경도 값을 포함하여 반환하도록 DTO를 만들고 변경했습니다.

---


[LCR-286]: https://lgcns-retail.atlassian.net/browse/LCR-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ