### PR TITLE
fix: GlobalResponseAdvice 적용 범위 조정으로 클라이언트 응답 구조 문제 수정

### DIFF
--- a/src/main/java/com/lgcns/global/common/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/lgcns/global/common/response/GlobalResponseAdvice.java
@@ -10,7 +10,24 @@ import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-@RestControllerAdvice(basePackages = "com.lgcns.externalApi")
+@RestControllerAdvice(
+        basePackages = {
+            "com.lgcns.domain.auth.externalApi",
+            "com.lgcns.domain.congestionStats.externalApi",
+            "com.lgcns.domain.conversionStats.externalApi",
+            "com.lgcns.domain.entrance.externalApi",
+            "com.lgcns.domain.image.externalApi",
+            "com.lgcns.domain.item.externalApi",
+            "com.lgcns.domain.itemAnalysis.externalApi",
+            "com.lgcns.domain.manager.externalApi",
+            "com.lgcns.domain.notification.externalApi",
+            "com.lgcns.domain.paymentStats.externalApi",
+            "com.lgcns.domain.popup.externalApi",
+            "com.lgcns.domain.reservation.externalApi",
+            "com.lgcns.domain.reservationStats.externalApi",
+            "com.lgcns.domain.survey.externalApi",
+            "com.lgcns.domain.visitorStats.externalApi"
+        })
 public class GlobalResponseAdvice implements ResponseBodyAdvice {
 
     @Override


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-287]

---
## 📌 작업 내용 및 특이사항

- 기존에는 GlobalResponseAdvice의 basePackages 설정이 광범위하여 실제 externalApi에 위치한 컨트롤러에 적용되지 않았습니다.
- 응답이 감싸지지 않아 클라이언트에서 예외가 발생하는 문제가 있어, externalApi 패키지 경로로 명확히 지정하여 응답 포맷이 정상적으로 감싸지도록 수정했습니다.


[LCR-287]: https://lgcns-retail.atlassian.net/browse/LCR-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ