### PR TITLE
test: 테스트 실행일에 따라 조회되지 않는 팝업 테스트 데이터 수정 및 Kafka 테스트 안정화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,6 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
-
-    // Awaitility
-    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,9 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    // Awaitility
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 dependencyManagement {

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -1,6 +1,7 @@
 package com.lgcns.domain.item.kafka;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.item.domain.Item;
@@ -10,6 +11,7 @@ import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.repository.PopupRepository;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -92,9 +94,13 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
         kafkaTemplate.send("item-purchased-topic", message);
 
         // then
-        Thread.sleep(2000);
-
-        assertThat(itemRepository.findById(1L).orElseThrow().getStock()).isEqualTo(48);
-        assertThat(itemRepository.findById(2L).orElseThrow().getStock()).isEqualTo(97);
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(
+                        () -> {
+                            assertThat(itemRepository.findById(1L).orElseThrow().getStock())
+                                    .isEqualTo(48);
+                            assertThat(itemRepository.findById(2L).orElseThrow().getStock())
+                                    .isEqualTo(97);
+                        });
     }
 }

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
@@ -30,6 +31,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
+@Order(0)
 @EmbeddedKafka(partitions = 1, topics = "item-purchased-topic")
 class ItemPurchasedConsumerTest extends IntegrationTest {
 
@@ -71,7 +73,7 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
     }
 
     @Test
-    void Kafka_메시지_수신_후_재고가_감소한다() throws InterruptedException {
+    void Kafka_메시지_수신_후_재고가_감소한다() {
         // given
         Map<String, Object> producerProps = KafkaTestUtils.producerProps(embeddedKafkaBroker);
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 class ItemServiceTest extends IntegrationTest {
@@ -110,8 +109,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 상품_등록 {
+
         @Test
-        @Transactional
         void 유효한_입력_값이면_상품_등록에_성공한다() {
             // given
             ItemCreateRequest request = createItemCreateRequest();
@@ -132,7 +131,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_팝업_ID로_상품_등록을_시도하면_실패한다() {
             // given
             final Long popupId = 9999L;
@@ -149,7 +147,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 권한이_없는_사용자가_상품을_등록하면_예외가_발생한다() {
             // give
             setAuthentication(otherManager);
@@ -165,8 +162,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 엑셀_파일_상품_등록 {
+
         @Test
-        @Transactional
         void 유효한_엑셀파일로_상품_등록에_성공한다() throws IOException {
             // given
             MultipartFile excelFile = createExcelFile();
@@ -211,7 +208,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_팝업_ID로_엑셀_상품_등록을_시도하면_실패한다() throws IOException {
             // given
             MultipartFile excelFile = createExcelFile();
@@ -274,7 +270,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 권한이_없는_사용자가_엑셀로_상품을_등록하면_예외가_발생한다() throws IOException {
             // given
             setAuthentication(otherManager);
@@ -290,8 +285,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 상품_목록_조회 {
+
         @Test
-        @Transactional
         void 상품_목록_조회에_성공한다() {
             // given
             final Long popupId = popup.getId();
@@ -356,7 +351,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 여러_위치에_존재하는_상품_목록을_조회한다() {
             //  given
             Long popupId = popup.getId();
@@ -417,8 +411,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 상품_삭제 {
+
         @Test
-        @Transactional
         void 정상적으로_상품을_삭제한다() {
             // given
             Item savedItem = createTestItem();
@@ -431,7 +425,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_상품을_삭제하면_예외가_발생한다() {
             // given
             Long nonExistentItemId = 9999L;
@@ -443,7 +436,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 상품이_해당_팝업에_속하지_않으면_예외가_발생한다() {
             // given
             Item savedItem = createTestItem();
@@ -459,8 +451,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 상품_최소_발주_수량_수정 {
+
         @Test
-        @Transactional
         void 정상적으로_최소_발주_수량_수정에_성공한다() {
             // given
             Item savedItem = createTestItem(); // 기본 minStock = 10
@@ -480,7 +472,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 성공_응답에_알맞은_상품_정보가_포함되어있다() {
             // given
             Item savedItem = createTestItem();
@@ -506,7 +497,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_상품의_최소_발주_수량을_수정하면_예외가_발생한다() {
             // given
             final Long popupId = popup.getId();
@@ -523,7 +513,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 권한이_없는_사용자가_최소_발주_수량을_수정하면_예외가_발생한다() {
             // given
             Item savedItem = createTestItem();
@@ -543,7 +532,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 상품이_해당_팝업에_속하지_않으면_예외가_발생한다() {
             // given
             Item savedItem = createTestItem();
@@ -562,7 +550,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 최소_발주_수량이_재고보다_크면_예외가_발생한다() {
             // given
             Item savedItem = createTestItem(); // stock = 100
@@ -581,8 +568,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 내부용_상품_목록을_조회할_때 {
+
         @Test
-        @Transactional
         void 데이터가_존재하면_상품_목록_조회에_성공한다() {
             // given
             final Long popupId = popup.getId();
@@ -620,7 +607,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 마지막_상품까지_조회하면_is_last가_true를_반환한다() {
             // given
             final Long popupId = popup.getId();
@@ -654,7 +640,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 검색어에_대해_결과가_존재하면_상품_검색에_성공한다() {
             // given
             final Long popupId = popup.getId();
@@ -692,7 +677,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 검색어에_대해_결과가_없으면_빈_리스트를_반환한다() {
             // given
             final Long popupId = popup.getId();
@@ -717,8 +701,8 @@ class ItemServiceTest extends IntegrationTest {
 
     @Nested
     class 내부용_기본_상품_목록을_조회할_때 {
+
         @Test
-        @Transactional
         void 무작위로_선택된_4개의_상품_조회에_성공한다() {
             // given
             final Long popupId = popup.getId();
@@ -751,7 +735,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 상품_데이터가_4개보다_적으면_전체_데이터_수_만큼_상품이_조회된다() {
             // given
             final Long popupId = popup.getId();
@@ -785,7 +768,6 @@ class ItemServiceTest extends IntegrationTest {
     class 결제_준비용_상품_상세_목록을_조회할_때 {
 
         @Test
-        @Transactional
         void 요청한_itemId_목록에_해당하는_상품_정보를_반환한다() {
             // given
             final Long popupId = popup.getId();
@@ -824,7 +806,6 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_itemId가_포함된_경우_해당_상품을_제외하고_존재하는_상품_정보만_반환한다() {
             // given
             final Long popupId = popup.getId();

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -463,7 +463,6 @@ public class PopupServiceTest extends IntegrationTest {
     class 지도_기반_팝업_리스트를_조회할_때 {
 
         @Test
-        @Transactional
         void 지정된_범위_내에_팝업이_존재할_때_해당_팝업들을_반환한다() {
             // given
             // 서울 전제에 해당하는 위,경도 범위
@@ -472,41 +471,39 @@ public class PopupServiceTest extends IntegrationTest {
             Double lngMin = 126.799543;
             Double lngMax = 127.184881;
 
-            Long popupId1 =
-                    createPopupWithAllParams(
-                            "강남 BLACKPINK 팝업스토어",
-                            "https://bucket/blackpink.jpg",
-                            LocalDate.of(2025, 5, 1),
-                            LocalDate.of(2025, 6, 1),
-                            LocalDateTime.of(2025, 4, 25, 10, 0),
-                            LocalDateTime.of(2025, 5, 31, 23, 59),
-                            LocalTime.of(10, 0),
-                            LocalTime.of(18, 0),
-                            100,
-                            10,
-                            "서울특별시 강남구 테헤란로 123",
-                            "3층",
-                            37.5,
-                            127.0,
-                            createDefaultChoices());
+            createPopupWithAllParams(
+                    "강남 BLACKPINK 팝업스토어",
+                    "https://bucket/blackpink.jpg",
+                    LocalDate.of(2025, 5, 1),
+                    LocalDate.of(2025, 7, 1),
+                    LocalDateTime.of(2025, 4, 25, 10, 0),
+                    LocalDateTime.of(2025, 5, 31, 23, 59),
+                    LocalTime.of(10, 0),
+                    LocalTime.of(18, 0),
+                    100,
+                    10,
+                    "서울특별시 강남구 테헤란로 123",
+                    "3층",
+                    37.5,
+                    127.0,
+                    createDefaultChoices());
 
-            Long popupId2 =
-                    createPopupWithAllParams(
-                            "홍대 BTS 팝업스토어",
-                            "https://bucket/bts.jpg",
-                            LocalDate.of(2025, 5, 15),
-                            LocalDate.of(2025, 6, 15),
-                            LocalDateTime.of(2025, 5, 10, 10, 0),
-                            LocalDateTime.of(2025, 6, 14, 23, 59),
-                            LocalTime.of(11, 0),
-                            LocalTime.of(19, 0),
-                            80,
-                            8,
-                            "서울특별시 마포구 홍익로 456",
-                            "2층",
-                            37.55,
-                            126.92,
-                            createDefaultChoices());
+            createPopupWithAllParams(
+                    "홍대 BTS 팝업스토어",
+                    "https://bucket/bts.jpg",
+                    LocalDate.of(2025, 5, 15),
+                    LocalDate.of(2025, 7, 15),
+                    LocalDateTime.of(2025, 5, 10, 10, 0),
+                    LocalDateTime.of(2025, 6, 14, 23, 59),
+                    LocalTime.of(11, 0),
+                    LocalTime.of(19, 0),
+                    80,
+                    8,
+                    "서울특별시 마포구 홍익로 456",
+                    "2층",
+                    37.55,
+                    126.92,
+                    createDefaultChoices());
 
             // when
             List<PopupMapResponse> result =
@@ -520,12 +517,12 @@ public class PopupServiceTest extends IntegrationTest {
                             assertThat(result.get(0).imageUrl())
                                     .isEqualTo("https://bucket/blackpink.jpg"),
                     () -> assertThat(result.get(0).popupOpenDate()).isEqualTo("2025-05-01"),
-                    () -> assertThat(result.get(0).popupCloseDate()).isEqualTo("2025-06-01"),
+                    () -> assertThat(result.get(0).popupCloseDate()).isEqualTo("2025-07-01"),
                     () -> assertThat(result.get(0).address()).isEqualTo("서울특별시 강남구 테헤란로 123, 3층"),
                     () -> assertThat(result.get(1).popupName()).isEqualTo("홍대 BTS 팝업스토어"),
                     () -> assertThat(result.get(1).imageUrl()).isEqualTo("https://bucket/bts.jpg"),
                     () -> assertThat(result.get(1).popupOpenDate()).isEqualTo("2025-05-15"),
-                    () -> assertThat(result.get(1).popupCloseDate()).isEqualTo("2025-06-15"),
+                    () -> assertThat(result.get(1).popupCloseDate()).isEqualTo("2025-07-15"),
                     () -> assertThat(result.get(1).address()).isEqualTo("서울특별시 마포구 홍익로 456, 2층"));
         }
 

--- a/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
+++ b/src/test/java/com/lgcns/domain/popup/service/PopupServiceTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 public class PopupServiceTest extends IntegrationTest {
     @Autowired private PopupService popupService;
@@ -57,8 +56,8 @@ public class PopupServiceTest extends IntegrationTest {
 
     @Nested
     class 팝업을_등록할_때 {
+
         @Test
-        @Transactional
         void 유효한_입력_값이면_팝업_등록에_성공한다() {
             // given
             PopupWithChoicesCreateRequest popupWithChoicesCreateRequest =
@@ -91,8 +90,8 @@ public class PopupServiceTest extends IntegrationTest {
 
     @Nested
     class 팝업_목록을_조회할_때 {
+
         @Test
-        @Transactional
         void 팝업_목록_조회에_성공한다() {
             // given
             createPopup();
@@ -111,13 +110,14 @@ public class PopupServiceTest extends IntegrationTest {
 
     @Nested
     class 팝업을_삭제할_때 {
+
         @Test
-        @Transactional
         void 정상적으로_팝업이_삭제된다() {
             // given
             Long popupId = createPopup();
 
             // when
+            reservationRepository.deleteAll();
             popupService.deletePopup(popupId);
 
             // then
@@ -125,7 +125,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_팝업을_삭제하면_예외가_발생한다() {
             // given
             final Long nonExistentPopupId = 9999L;
@@ -137,7 +136,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 권한이_없는_사용자가_팝업을_삭제하면_예외가_발생한다() {
             // given
             final Long popupId = createPopup();
@@ -153,8 +151,8 @@ public class PopupServiceTest extends IntegrationTest {
 
     @Nested
     class 내부용_팝업_목록을_조회할_때 {
+
         @Test
-        @Transactional
         void 운영중인_팝업이_존재하면_리스트를_반환한다() {
             LocalDate now = LocalDate.now();
 
@@ -182,7 +180,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 운영중인_팝업이_없으면_빈_리스트를_반환한다() {
             // given
             LocalDate now = LocalDate.now();
@@ -202,7 +199,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 페이징_처리가_정상적으로_동작한다() {
             // given
             LocalDate now = LocalDate.now();
@@ -233,7 +229,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 검색어에_대한_결과가_존재하면_결과_리스트를_반환한다() {
             // given
             LocalDate now = LocalDate.now();
@@ -264,7 +259,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 검색어에_대해_결과가_없으면_빈_리스트를_반환한다() {
             // given
             LocalDate now = LocalDate.now();
@@ -289,7 +283,6 @@ public class PopupServiceTest extends IntegrationTest {
     class 팝업_설문지_조회할_때 {
 
         @Test
-        @Transactional
         void 팝업_ID를_통해_설문지와_선지_조회에_성공한다() {
             // given
             Long popupId = createPopup();
@@ -311,7 +304,6 @@ public class PopupServiceTest extends IntegrationTest {
     class 내부용_팝업_상세_정보를_조회할_떼 {
 
         @Test
-        @Transactional
         void 존재하는_팝업_아이디로_상세_조회에_성공한다() {
             // given
             Long popupId = createPopup();
@@ -340,7 +332,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_팝업_아이디로_조회하면_예외를_발생시킨다() {
             // given
             final Long nonExistentPopupId = 999L;
@@ -356,7 +347,6 @@ public class PopupServiceTest extends IntegrationTest {
     class 예악된_팝업_정보_조회할_때 {
 
         @Test
-        @Transactional
         void 사용자가_예약한_팝업_ID_리스트를_통해_팝업_정보_조회에_성공한다() {
             // given
             Long popupId = createPopup();
@@ -383,7 +373,6 @@ public class PopupServiceTest extends IntegrationTest {
     class 팝업_아이디_리스트로_팝업_정보_리스트를_조회할_때 {
 
         @Test
-        @Transactional
         void 요청된_아이디가_4개보다_많은_경우_정확히_4개만_반환한다() {
             // given
             Long popupId1 = createPopup();
@@ -406,7 +395,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 요청된_아이디가_4개보다_적은_경우_부족한_개수만큼_랜덤으로_채워서_4개를_반환한다() {
             // given
             Long popupId1 = createPopup();
@@ -439,7 +427,6 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 전체_팝업이_4개_미만인_경우_존재하는_모든_팝업을_반환한다() {
             // given
             Long popupId1 = createPopup();
@@ -527,26 +514,24 @@ public class PopupServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 지정된_범위_내에_팝업이_존재하지_않으면_빈_리스트를_반환한다() {
             // given
-            Long popupId1 =
-                    createPopupWithAllParams(
-                            "부산 팝업스토어",
-                            "https://bucket/busan.jpg",
-                            LocalDate.of(2025, 5, 1),
-                            LocalDate.of(2025, 6, 1),
-                            LocalDateTime.of(2025, 4, 25, 10, 0),
-                            LocalDateTime.of(2025, 5, 31, 23, 59),
-                            LocalTime.of(10, 0),
-                            LocalTime.of(18, 0),
-                            100,
-                            10,
-                            "부산광역시 해운대구",
-                            "1층",
-                            35.1,
-                            129.0,
-                            createDefaultChoices());
+            createPopupWithAllParams(
+                    "부산 팝업스토어",
+                    "https://bucket/busan.jpg",
+                    LocalDate.of(2025, 5, 1),
+                    LocalDate.of(2025, 6, 1),
+                    LocalDateTime.of(2025, 4, 25, 10, 0),
+                    LocalDateTime.of(2025, 5, 31, 23, 59),
+                    LocalTime.of(10, 0),
+                    LocalTime.of(18, 0),
+                    100,
+                    10,
+                    "부산광역시 해운대구",
+                    "1층",
+                    35.1,
+                    129.0,
+                    createDefaultChoices());
 
             // 서울
             Double latMin = 37.378638;

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$OrderAnnotation


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-292]

---
## 📌 작업 내용 및 특이사항

- 팝업 종료일이 테스트 실행일 기준으로 지나 있어 조회되지 않는 문제가 발생해, 테스트 데이터의 종료일을 최종 프로젝트 마감일 이후(2025-07-xx)로 수정했습니다.
- DatabaseCleaner를 사용하고 있어 불필요한 ```@Transactional``` 어노테이션을 제거했습니다.
- Kafka 메시지 소비 테스트에서 Thread.sleep(2000)으로 메시지 소비를 기다리고 있었으나, CI 환경에서 불안정하게 작동하는 문제가 있었습니다.
- Awaitility를 적용해 메시지 소비 완료를 조건으로 검증하도록 개선했습니다.
- 또한 ```@EmbeddedKafka```가 포함된 클래스가 가장 먼저 실행되도록 ```@Order(0)```을 부여했습니다.
- 테스트 클래스 실행 순서를 junit-platform.properties에 설정해 JUnit이 ```@Order``` 기준으로 실행되도록 했습니다.
- 간헐적인 Kafka 컨슈머 테스트 실패를 방지하기 위해 테스트 실행 순서를 제어했습니다.


[LCR-292]: https://lgcns-retail.atlassian.net/browse/LCR-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ