### PR TITLE
refactor: 팝업별 1인 평균 구매액 스케줄링 저장 및 조회 로직 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/paymentStats/client/PaymentServiceClient.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/client/PaymentServiceClient.java
@@ -1,0 +1,16 @@
+package com.lgcns.domain.paymentStats.client;
+
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
+import com.lgcns.global.config.feign.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "${payment.service.name}",
+        url = "${payment.service.url:}",
+        configuration = FeignConfig.class)
+public interface PaymentServiceClient {
+    @GetMapping("/internal/{popupId}/average-purchase")
+    AverageAmountResponse findAverageAmount(@PathVariable(name = "popupId") Long popupId);
+}

--- a/src/main/java/com/lgcns/domain/paymentStats/domain/AveragePeriod.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/domain/AveragePeriod.java
@@ -1,0 +1,14 @@
+package com.lgcns.domain.paymentStats.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AveragePeriod {
+    TOTAL("TOTAL"),
+    TODAY("TODAY"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/lgcns/domain/paymentStats/domain/PaymentStats.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/domain/PaymentStats.java
@@ -21,42 +21,43 @@ public class PaymentStats {
     @Column(name = "popup_id")
     private Long popupId;
 
+    private int averageAmount;
+
+    @Enumerated(EnumType.STRING)
+    private AveragePeriod period;
+
     @Column(name = "analyzed_date")
     private LocalDate analyzedDate;
 
     @Column(name = "analyzed_time")
     private LocalTime analyzedTime;
 
-    private int totalPayment;
-
-    private int userCount;
-
     @Builder(access = AccessLevel.PRIVATE)
     public PaymentStats(
             Long popupId,
+            int averageAmount,
+            AveragePeriod period,
             LocalDate analyzedDate,
-            LocalTime analyzedTime,
-            int totalPayment,
-            int userCount) {
+            LocalTime analyzedTime) {
         this.popupId = popupId;
+        this.averageAmount = averageAmount;
+        this.period = period;
         this.analyzedDate = analyzedDate;
         this.analyzedTime = analyzedTime;
-        this.totalPayment = totalPayment;
-        this.userCount = userCount;
     }
 
     public static PaymentStats createPaymentStats(
             Long popupId,
+            int averageAmount,
+            AveragePeriod period,
             LocalDate analyzedDate,
-            LocalTime analyzedTime,
-            int totalPayment,
-            int userCount) {
+            LocalTime analyzedTime) {
         return PaymentStats.builder()
                 .popupId(popupId)
+                .averageAmount(averageAmount)
+                .period(period)
                 .analyzedDate(analyzedDate)
                 .analyzedTime(analyzedTime)
-                .totalPayment(totalPayment)
-                .userCount(userCount)
                 .build();
     }
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/dto/response/AverageAmountResponse.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/dto/response/AverageAmountResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.paymentStats.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AverageAmountResponse(
+        @Schema(description = "전체 기간 1인 평균 구매액", example = "30000") Integer totalAverageAmount,
+        @Schema(description = "오늘 1인 평균 구매액", example = "5000") Integer todayAverageAmount) {}

--- a/src/main/java/com/lgcns/domain/paymentStats/dto/response/AverageAmountResponse.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/dto/response/AverageAmountResponse.java
@@ -4,4 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AverageAmountResponse(
         @Schema(description = "전체 기간 1인 평균 구매액", example = "30000") Integer totalAverageAmount,
-        @Schema(description = "오늘 1인 평균 구매액", example = "5000") Integer todayAverageAmount) {}
+        @Schema(description = "오늘 1인 평균 구매액", example = "5000") Integer todayAverageAmount) {
+    public static AverageAmountResponse of(Integer totalAverageAmount, Integer todayAverageAmount) {
+        return new AverageAmountResponse(totalAverageAmount, todayAverageAmount);
+    }
+}

--- a/src/main/java/com/lgcns/domain/paymentStats/dto/response/PaymentAverageResponse.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/dto/response/PaymentAverageResponse.java
@@ -1,3 +1,0 @@
-package com.lgcns.domain.paymentStats.dto.response;
-
-public record PaymentAverageResponse(Integer totalPrice, Integer todayPrice) {}

--- a/src/main/java/com/lgcns/domain/paymentStats/externalApi/PaymentStatsController.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/externalApi/PaymentStatsController.java
@@ -1,6 +1,6 @@
 package com.lgcns.domain.paymentStats.externalApi;
 
-import com.lgcns.domain.paymentStats.dto.response.PaymentAverageResponse;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.domain.paymentStats.service.PaymentStatsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,7 +20,7 @@ public class PaymentStatsController {
 
     @GetMapping("/average-purchase")
     @Operation(summary = "1인당 평균 구매액 조회", description = "팝업의 총 평균 구매액과 오늘의 평균 구매액을 조회합니다.")
-    public PaymentAverageResponse paymentAverageGet(@PathVariable Long popupId) {
+    public AverageAmountResponse paymentAverageGet(@PathVariable Long popupId) {
         return paymentStatsService.getPaymentAverages(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/externalApi/PaymentStatsController.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/externalApi/PaymentStatsController.java
@@ -20,7 +20,7 @@ public class PaymentStatsController {
 
     @GetMapping("/average-purchase")
     @Operation(summary = "1인당 평균 구매액 조회", description = "팝업의 총 평균 구매액과 오늘의 평균 구매액을 조회합니다.")
-    public AverageAmountResponse paymentAverageGet(@PathVariable Long popupId) {
-        return paymentStatsService.getPaymentAverages(popupId);
+    public AverageAmountResponse averageAmountFind(@PathVariable Long popupId) {
+        return paymentStatsService.findLatestAverageAmount(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryCustom.java
@@ -1,8 +1,8 @@
 package com.lgcns.domain.paymentStats.repository;
 
-import com.lgcns.domain.paymentStats.dto.response.PaymentAverageResponse;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import java.time.LocalDate;
 
 public interface PaymentStatsRepositoryCustom {
-    PaymentAverageResponse getPaymentAverages(Long popupId, LocalDate today);
+    AverageAmountResponse getPaymentAverages(Long popupId, LocalDate today);
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryCustom.java
@@ -1,7 +1,11 @@
 package com.lgcns.domain.paymentStats.repository;
 
+import com.lgcns.domain.paymentStats.domain.PaymentStats;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
+import java.util.List;
 
 public interface PaymentStatsRepositoryCustom {
     AverageAmountResponse findLatestAverageAmountByPopupId(Long popupId);
+
+    void bulkInsertPaymentStats(List<PaymentStats> statsList);
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryCustom.java
@@ -1,8 +1,7 @@
 package com.lgcns.domain.paymentStats.repository;
 
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
-import java.time.LocalDate;
 
 public interface PaymentStatsRepositoryCustom {
-    AverageAmountResponse getPaymentAverages(Long popupId, LocalDate today);
+    AverageAmountResponse findLatestAverageAmountByPopupId(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
@@ -2,9 +2,8 @@ package com.lgcns.domain.paymentStats.repository;
 
 import static com.lgcns.domain.paymentStats.domain.QPaymentStats.paymentStats;
 
+import com.lgcns.domain.paymentStats.domain.AveragePeriod;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -13,38 +12,35 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class PaymentStatsRepositoryImpl implements PaymentStatsRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
 
-    public AverageAmountResponse getPaymentAverages(Long popupId, LocalDate today) {
-        NumberExpression<Double> avgExpression =
-                new CaseBuilder()
-                        .when(paymentStats.userCount.sum().eq(0))
-                        .then(0.0)
-                        .otherwise(
-                                paymentStats
-                                        .totalPayment
-                                        .sum()
-                                        .doubleValue()
-                                        .divide(paymentStats.userCount.sum().doubleValue()));
-
-        Double totalAvg =
+    @Override
+    public AverageAmountResponse findLatestAverageAmountByPopupId(Long popupId) {
+        Integer totalAverageAmount =
                 queryFactory
-                        .select(avgExpression)
-                        .from(paymentStats)
-                        .where(paymentStats.popupId.eq(popupId))
-                        .fetchOne();
-
-        Double todayAvg =
-                queryFactory
-                        .select(avgExpression)
+                        .select(paymentStats.averageAmount)
                         .from(paymentStats)
                         .where(
                                 paymentStats.popupId.eq(popupId),
-                                paymentStats.analyzedDate.eq(today))
-                        .fetchOne();
+                                paymentStats.period.eq(AveragePeriod.TOTAL))
+                        .orderBy(paymentStats.analyzedTime.desc())
+                        .fetchFirst();
 
-        return new AverageAmountResponse(
-                (int) Math.round(totalAvg != null ? totalAvg : 0),
-                (int) Math.round(todayAvg != null ? todayAvg : 0));
+        Integer todayAverageAmount =
+                queryFactory
+                        .select(paymentStats.averageAmount)
+                        .from(paymentStats)
+                        .where(
+                                paymentStats.popupId.eq(popupId),
+                                paymentStats.period.eq(AveragePeriod.TODAY),
+                                paymentStats.analyzedDate.eq(LocalDate.now()))
+                        .orderBy(paymentStats.analyzedTime.desc())
+                        .fetchFirst();
+
+        totalAverageAmount = totalAverageAmount != null ? totalAverageAmount : 0;
+        todayAverageAmount = todayAverageAmount != null ? todayAverageAmount : 0;
+
+        return AverageAmountResponse.of(totalAverageAmount, todayAverageAmount);
     }
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
@@ -3,9 +3,12 @@ package com.lgcns.domain.paymentStats.repository;
 import static com.lgcns.domain.paymentStats.domain.QPaymentStats.paymentStats;
 
 import com.lgcns.domain.paymentStats.domain.AveragePeriod;
+import com.lgcns.domain.paymentStats.domain.PaymentStats;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +16,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class PaymentStatsRepositoryImpl implements PaymentStatsRepositoryCustom {
 
+    private final EntityManager em;
     private final JPAQueryFactory queryFactory;
 
     @Override
@@ -42,5 +46,37 @@ public class PaymentStatsRepositoryImpl implements PaymentStatsRepositoryCustom 
         todayAverageAmount = todayAverageAmount != null ? todayAverageAmount : 0;
 
         return AverageAmountResponse.of(totalAverageAmount, todayAverageAmount);
+    }
+
+    @Override
+    public void bulkInsertPaymentStats(List<PaymentStats> statsList) {
+        if (statsList.isEmpty()) return;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(
+                "INSERT INTO payment_stats (popup_id, average_amount, period, analyzed_date, analyzed_time) VALUES ");
+
+        for (int i = 0; i < statsList.size(); i++) {
+            PaymentStats ps = statsList.get(i);
+            sb.append("(")
+                    .append(ps.getPopupId())
+                    .append(", ")
+                    .append(ps.getAverageAmount())
+                    .append(", ")
+                    .append("'")
+                    .append(ps.getPeriod().name())
+                    .append("', ")
+                    .append("'")
+                    .append(ps.getAnalyzedDate())
+                    .append("', ")
+                    .append("'")
+                    .append(ps.getAnalyzedTime())
+                    .append("'")
+                    .append(")");
+
+            if (i < statsList.size() - 1) sb.append(", ");
+        }
+
+        em.createNativeQuery(sb.toString()).executeUpdate();
     }
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/repository/PaymentStatsRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.lgcns.domain.paymentStats.repository;
 
 import static com.lgcns.domain.paymentStats.domain.QPaymentStats.paymentStats;
 
-import com.lgcns.domain.paymentStats.dto.response.PaymentAverageResponse;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Repository;
 public class PaymentStatsRepositoryImpl implements PaymentStatsRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
-    public PaymentAverageResponse getPaymentAverages(Long popupId, LocalDate today) {
+    public AverageAmountResponse getPaymentAverages(Long popupId, LocalDate today) {
         NumberExpression<Double> avgExpression =
                 new CaseBuilder()
                         .when(paymentStats.userCount.sum().eq(0))
@@ -43,7 +43,7 @@ public class PaymentStatsRepositoryImpl implements PaymentStatsRepositoryCustom 
                                 paymentStats.analyzedDate.eq(today))
                         .fetchOne();
 
-        return new PaymentAverageResponse(
+        return new AverageAmountResponse(
                 (int) Math.round(totalAvg != null ? totalAvg : 0),
                 (int) Math.round(todayAvg != null ? todayAvg : 0));
     }

--- a/src/main/java/com/lgcns/domain/paymentStats/scheduler/PaymentStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/scheduler/PaymentStatsScheduler.java
@@ -1,0 +1,69 @@
+package com.lgcns.domain.paymentStats.scheduler;
+
+import com.lgcns.domain.paymentStats.client.PaymentServiceClient;
+import com.lgcns.domain.paymentStats.domain.AveragePeriod;
+import com.lgcns.domain.paymentStats.domain.PaymentStats;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
+import com.lgcns.domain.paymentStats.repository.PaymentStatsRepository;
+import com.lgcns.domain.popup.repository.PopupRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentStatsScheduler {
+
+    private final PopupRepository popupRepository;
+    private final PaymentServiceClient paymentServiceClient;
+    private final PaymentStatsRepository paymentStatsRepository;
+
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void createPaymentStats() {
+        List<Long> popupIds = popupRepository.findAllPopupIds();
+
+        List<PaymentStats> batch = new ArrayList<>();
+
+        for (Long popupId : popupIds) {
+            try {
+                AverageAmountResponse response = paymentServiceClient.findAverageAmount(popupId);
+
+                PaymentStats totalStats =
+                        PaymentStats.createPaymentStats(
+                                popupId,
+                                response.totalAverageAmount(),
+                                AveragePeriod.TOTAL,
+                                LocalDate.now(),
+                                LocalTime.now());
+
+                PaymentStats todayStats =
+                        PaymentStats.createPaymentStats(
+                                popupId,
+                                response.todayAverageAmount(),
+                                AveragePeriod.TODAY,
+                                LocalDate.now(),
+                                LocalTime.now());
+
+                batch.add(totalStats);
+                batch.add(todayStats);
+
+            } catch (Exception e) {
+                log.warn("Failed to prepare stats for popupId: {}", popupId, e);
+            }
+        }
+
+        if (!batch.isEmpty()) {
+            try {
+                paymentStatsRepository.bulkInsertPaymentStats(batch);
+            } catch (Exception e) {
+                log.error("Failed to insert payment stats batch", e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/lgcns/domain/paymentStats/scheduler/PaymentStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/scheduler/PaymentStatsScheduler.java
@@ -1,15 +1,6 @@
 package com.lgcns.domain.paymentStats.scheduler;
 
-import com.lgcns.domain.paymentStats.client.PaymentServiceClient;
-import com.lgcns.domain.paymentStats.domain.AveragePeriod;
-import com.lgcns.domain.paymentStats.domain.PaymentStats;
-import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
-import com.lgcns.domain.paymentStats.repository.PaymentStatsRepository;
-import com.lgcns.domain.popup.repository.PopupRepository;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
+import com.lgcns.domain.paymentStats.service.PaymentStatsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -20,50 +11,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PaymentStatsScheduler {
 
-    private final PopupRepository popupRepository;
-    private final PaymentServiceClient paymentServiceClient;
-    private final PaymentStatsRepository paymentStatsRepository;
+    private final PaymentStatsService paymentStatsService;
 
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void createPaymentStats() {
-        List<Long> popupIds = popupRepository.findAllPopupIds();
-
-        List<PaymentStats> batch = new ArrayList<>();
-
-        for (Long popupId : popupIds) {
-            try {
-                AverageAmountResponse response = paymentServiceClient.findAverageAmount(popupId);
-
-                PaymentStats totalStats =
-                        PaymentStats.createPaymentStats(
-                                popupId,
-                                response.totalAverageAmount(),
-                                AveragePeriod.TOTAL,
-                                LocalDate.now(),
-                                LocalTime.now());
-
-                PaymentStats todayStats =
-                        PaymentStats.createPaymentStats(
-                                popupId,
-                                response.todayAverageAmount(),
-                                AveragePeriod.TODAY,
-                                LocalDate.now(),
-                                LocalTime.now());
-
-                batch.add(totalStats);
-                batch.add(todayStats);
-
-            } catch (Exception e) {
-                log.warn("Failed to prepare stats for popupId: {}", popupId, e);
-            }
-        }
-
-        if (!batch.isEmpty()) {
-            try {
-                paymentStatsRepository.bulkInsertPaymentStats(batch);
-            } catch (Exception e) {
-                log.error("Failed to insert payment stats batch", e);
-            }
-        }
+        paymentStatsService.createPaymentStats();
     }
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsService.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsService.java
@@ -1,7 +1,7 @@
 package com.lgcns.domain.paymentStats.service;
 
-import com.lgcns.domain.paymentStats.dto.response.PaymentAverageResponse;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 
 public interface PaymentStatsService {
-    PaymentAverageResponse getPaymentAverages(Long popupId);
+    AverageAmountResponse getPaymentAverages(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsService.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsService.java
@@ -4,4 +4,6 @@ import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 
 public interface PaymentStatsService {
     AverageAmountResponse findLatestAverageAmount(Long popupId);
+
+    void createPaymentStats();
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsService.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsService.java
@@ -3,5 +3,5 @@ package com.lgcns.domain.paymentStats.service;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 
 public interface PaymentStatsService {
-    AverageAmountResponse getPaymentAverages(Long popupId);
+    AverageAmountResponse findLatestAverageAmount(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
@@ -1,6 +1,9 @@
 package com.lgcns.domain.paymentStats.service;
 
 import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.paymentStats.client.PaymentServiceClient;
+import com.lgcns.domain.paymentStats.domain.AveragePeriod;
+import com.lgcns.domain.paymentStats.domain.PaymentStats;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.domain.paymentStats.repository.PaymentStatsRepository;
 import com.lgcns.domain.popup.domain.Popup;
@@ -8,6 +11,10 @@ import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,14 +29,59 @@ public class PaymentStatsServiceImpl implements PaymentStatsService {
     private final ManagerUtil managerUtil;
     private final PopupRepository popupRepository;
     private final PaymentStatsRepository paymentStatsRepository;
+    private final PaymentServiceClient paymentServiceClient;
 
     @Override
+    @Transactional(readOnly = true)
     public AverageAmountResponse findLatestAverageAmount(Long popupId) {
         final Manager currentManager = managerUtil.getCurrentManager();
         final Popup popup = findPopupById(popupId);
         validatePopupOwnership(currentManager, popup);
 
         return paymentStatsRepository.findLatestAverageAmountByPopupId(popupId);
+    }
+
+    @Override
+    public void createPaymentStats() {
+        List<Long> popupIds = popupRepository.findAllPopupIds();
+
+        List<PaymentStats> statsList = new ArrayList<>();
+
+        for (Long popupId : popupIds) {
+            try {
+                AverageAmountResponse response = paymentServiceClient.findAverageAmount(popupId);
+
+                PaymentStats totalStats =
+                        PaymentStats.createPaymentStats(
+                                popupId,
+                                response.totalAverageAmount(),
+                                AveragePeriod.TOTAL,
+                                LocalDate.now(),
+                                LocalTime.now());
+
+                PaymentStats todayStats =
+                        PaymentStats.createPaymentStats(
+                                popupId,
+                                response.todayAverageAmount(),
+                                AveragePeriod.TODAY,
+                                LocalDate.now(),
+                                LocalTime.now());
+
+                statsList.add(totalStats);
+                statsList.add(todayStats);
+
+            } catch (Exception e) {
+                log.warn("Failed to prepare stats for popupId: {}", popupId, e);
+            }
+        }
+
+        if (!statsList.isEmpty()) {
+            try {
+                paymentStatsRepository.bulkInsertPaymentStats(statsList);
+            } catch (Exception e) {
+                log.error("Failed to insert payment stats batch", e);
+            }
+        }
     }
 
     private Popup findPopupById(Long popupId) {

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
@@ -8,31 +8,28 @@ import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class PaymentStatsServiceImpl implements PaymentStatsService {
 
-    private final PaymentStatsRepository paymentStatsRepository;
-    private final PopupRepository popupRepository;
     private final ManagerUtil managerUtil;
+    private final PopupRepository popupRepository;
+    private final PaymentStatsRepository paymentStatsRepository;
 
     @Override
-    @Transactional(readOnly = true)
-    public AverageAmountResponse getPaymentAverages(Long popupId) {
-        Manager currentManager = managerUtil.getCurrentManager();
-        Popup popup = findPopupById(popupId);
-
+    public AverageAmountResponse findLatestAverageAmount(Long popupId) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+        final Popup popup = findPopupById(popupId);
         validatePopupOwnership(currentManager, popup);
 
-        final LocalDate today = LocalDate.now();
-
-        return paymentStatsRepository.getPaymentAverages(popupId, today);
+        return paymentStatsRepository.findLatestAverageAmountByPopupId(popupId);
     }
 
     private Popup findPopupById(Long popupId) {

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
@@ -1,7 +1,7 @@
 package com.lgcns.domain.paymentStats.service;
 
 import com.lgcns.domain.manager.domain.Manager;
-import com.lgcns.domain.paymentStats.dto.response.PaymentAverageResponse;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.domain.paymentStats.repository.PaymentStatsRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
@@ -24,7 +24,7 @@ public class PaymentStatsServiceImpl implements PaymentStatsService {
 
     @Override
     @Transactional(readOnly = true)
-    public PaymentAverageResponse getPaymentAverages(Long popupId) {
+    public AverageAmountResponse getPaymentAverages(Long popupId) {
         Manager currentManager = managerUtil.getCurrentManager();
         Popup popup = findPopupById(popupId);
 

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepository.java
@@ -3,7 +3,9 @@ package com.lgcns.domain.popup.repository;
 import com.lgcns.domain.popup.domain.Popup;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PopupRepository extends JpaRepository<Popup, Long>, PopupRepositoryCustom {
-    List<Popup> findAllByManagerIdOrderByIdDesc(Long managerId);
+    @Query("select p.id from Popup p")
+    List<Long> findAllPopupIds();
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,3 +27,7 @@ eureka:
 reservation:
   service:
     name: reservations
+
+payment:
+  service:
+    name: payments

--- a/src/main/resources/db/migration/V28__alter_payment_stats_table_add_average_columns.sql
+++ b/src/main/resources/db/migration/V28__alter_payment_stats_table_add_average_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE payment_stats DROP COLUMN total_payment;
+ALTER TABLE payment_stats DROP COLUMN user_count;
+
+ALTER TABLE payment_stats ADD COLUMN average_amount INT NOT NULL;
+ALTER TABLE payment_stats ADD COLUMN period ENUM('TOTAL', 'TODAY') NOT NULL;

--- a/src/main/resources/db/migration/V30__delete_all_payment_stats_table.sql
+++ b/src/main/resources/db/migration/V30__delete_all_payment_stats_table.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE payment_stats;

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -96,7 +96,7 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
         kafkaTemplate.send("item-purchased-topic", message);
 
         // then
-        await().atMost(Duration.ofSeconds(5))
+        await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(
                         () -> {
                             assertThat(itemRepository.findById(1L).orElseThrow().getStock())

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -7,7 +7,7 @@ import com.lgcns.IntegrationTest;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.paymentStats.domain.PaymentStats;
-import com.lgcns.domain.paymentStats.dto.response.PaymentAverageResponse;
+import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.domain.paymentStats.repository.PaymentStatsRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
@@ -115,12 +115,12 @@ class PaymentStatsServiceTest extends IntegrationTest {
             Long popupId = popup.getId();
 
             // when
-            PaymentAverageResponse response = paymentStatsService.getPaymentAverages(popupId);
+            AverageAmountResponse response = paymentStatsService.getPaymentAverages(popupId);
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.totalPrice()).isNotNull();
-            assertThat(response.todayPrice()).isNotNull();
+            assertThat(response.totalAverageAmount()).isNotNull();
+            assertThat(response.todayAverageAmount()).isNotNull();
         }
 
         @Test
@@ -188,11 +188,11 @@ class PaymentStatsServiceTest extends IntegrationTest {
                             popup.getId(), today, LocalTime.of(12, 0), 60000, 10));
 
             // when
-            PaymentAverageResponse response = paymentStatsService.getPaymentAverages(popupId);
+            AverageAmountResponse response = paymentStatsService.getPaymentAverages(popupId);
 
             // then
-            assertThat(response.totalPrice()).isEqualTo(5000);
-            assertThat(response.todayPrice()).isEqualTo(6000);
+            assertThat(response.totalAverageAmount()).isEqualTo(5000);
+            assertThat(response.todayAverageAmount()).isEqualTo(6000);
         }
 
         @Test
@@ -203,11 +203,11 @@ class PaymentStatsServiceTest extends IntegrationTest {
             paymentStatsRepository.deleteAll();
 
             // when
-            PaymentAverageResponse response = paymentStatsService.getPaymentAverages(popupId);
+            AverageAmountResponse response = paymentStatsService.getPaymentAverages(popupId);
 
             // then
-            assertThat(response.totalPrice()).isEqualTo(0);
-            assertThat(response.todayPrice()).isEqualTo(0);
+            assertThat(response.totalAverageAmount()).isEqualTo(0);
+            assertThat(response.todayAverageAmount()).isEqualTo(0);
         }
     }
 }

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -17,12 +17,11 @@ import com.lgcns.global.error.exception.CustomException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 class PaymentStatsServiceTest extends IntegrationTest {
 
@@ -63,75 +62,80 @@ class PaymentStatsServiceTest extends IntegrationTest {
                         127.123456);
         popup = popupRepository.save(popup);
 
-        createTestPaymentStats();
-    }
-
-    private void createTestPaymentStats() {
-        paymentStatsRepository.save(
+        PaymentStats paymentStats1 =
                 PaymentStats.createPaymentStats(
                         popup.getId(),
                         10080,
                         AveragePeriod.TOTAL,
                         LocalDate.of(2025, 5, 2),
-                        LocalTime.of(8, 0)));
+                        LocalTime.of(8, 0));
 
-        paymentStatsRepository.save(
+        PaymentStats paymentStats2 =
                 PaymentStats.createPaymentStats(
                         popup.getId(),
                         15032,
                         AveragePeriod.TOTAL,
                         LocalDate.of(2025, 5, 2),
-                        LocalTime.of(10, 0)));
+                        LocalTime.of(10, 0));
 
-        paymentStatsRepository.save(
+        PaymentStats paymentStats3 =
                 PaymentStats.createPaymentStats(
                         popup.getId(),
                         19048,
                         AveragePeriod.TOTAL,
                         LocalDate.of(2025, 5, 2),
-                        LocalTime.of(12, 0)));
+                        LocalTime.of(12, 0));
 
-        paymentStatsRepository.save(
+        PaymentStats paymentStats4 =
                 PaymentStats.createPaymentStats(
                         popup.getId(),
                         21794,
                         AveragePeriod.TOTAL,
                         LocalDate.of(2025, 5, 3),
-                        LocalTime.of(14, 0)));
+                        LocalTime.of(14, 0));
 
-        LocalDate today = LocalDate.now();
-        paymentStatsRepository.save(
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        10000,
-                        AveragePeriod.TODAY,
-                        today,
-                        LocalTime.of(8, 0))); // 980000 / 98
+        PaymentStats paymentStats5 =
+                paymentStatsRepository.save(
+                        PaymentStats.createPaymentStats(
+                                popup.getId(),
+                                10000,
+                                AveragePeriod.TODAY,
+                                LocalDate.now(),
+                                LocalTime.of(8, 0)));
 
-        paymentStatsRepository.save(
+        PaymentStats paymentStats6 =
                 PaymentStats.createPaymentStats(
                         popup.getId(),
                         12900,
                         AveragePeriod.TODAY,
-                        today,
-                        LocalTime.of(10, 0))); // 1870000 / 145
+                        LocalDate.now(),
+                        LocalTime.of(10, 0));
 
-        paymentStatsRepository.save(
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        21237,
-                        AveragePeriod.TODAY,
-                        today,
-                        LocalTime.of(12, 0))); // 4120000 / 194
+        PaymentStats paymentStats7 =
+                paymentStatsRepository.save(
+                        PaymentStats.createPaymentStats(
+                                popup.getId(),
+                                21237,
+                                AveragePeriod.TODAY,
+                                LocalDate.now(),
+                                LocalTime.of(12, 0)));
+
+        paymentStatsRepository.saveAll(
+                List.of(
+                        paymentStats1,
+                        paymentStats2,
+                        paymentStats3,
+                        paymentStats4,
+                        paymentStats5,
+                        paymentStats6,
+                        paymentStats7));
     }
 
     @Nested
-    @DisplayName("평균 결제액 조회 테스트")
-    class GetPaymentAverageTest {
+    class 평균_구매액을_조회할_때 {
 
         @Test
-        @Transactional
-        void 정상적으로_평균_결제액_조회에_성공한다() {
+        void 정상적으로_평균_구매액_조회에_성공한다() {
             // given
             Long popupId = popup.getId();
 
@@ -145,7 +149,6 @@ class PaymentStatsServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 존재하지_않는_팝업_ID로_조회하면_예외가_발생한다() {
             // given
             Long nonExistentPopupId = 9999L;
@@ -158,7 +161,6 @@ class PaymentStatsServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 다른_매니저의_팝업에_접근하면_예외가_발생한다() {
             // given
             Popup otherPopup =
@@ -188,30 +190,27 @@ class PaymentStatsServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 계산된_1인당_구매_평균값이_정확한지_확인한다() {
             // given
-            Long popupId = popup.getId();
-
             paymentStatsRepository.deleteAll();
 
-            // 단순한 데이터 시나리오 구성
-            // 전체 기간: 결제액 100,000원, 방문자 20명 -> 1인당 5,000원
-            // 오늘: 결제액 60,000원, 방문자 10명 -> 1인당 6,000원
-            LocalDate today = LocalDate.now();
+            Long popupId = popup.getId();
 
-            // 초기
             paymentStatsRepository.save(
                     PaymentStats.createPaymentStats(
                             popup.getId(),
                             5000,
                             AveragePeriod.TOTAL,
-                            today.minusDays(1),
+                            LocalDate.now().minusDays(1),
                             LocalTime.of(12, 0)));
 
             paymentStatsRepository.save(
                     PaymentStats.createPaymentStats(
-                            popup.getId(), 6000, AveragePeriod.TODAY, today, LocalTime.of(12, 0)));
+                            popup.getId(),
+                            6000,
+                            AveragePeriod.TODAY,
+                            LocalDate.now(),
+                            LocalTime.of(12, 0)));
 
             // when
             AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
@@ -222,11 +221,11 @@ class PaymentStatsServiceTest extends IntegrationTest {
         }
 
         @Test
-        @Transactional
         void 데이터가_없을_경우_0을_반환한다() {
             // given
-            Long popupId = popup.getId();
             paymentStatsRepository.deleteAll();
+
+            Long popupId = popup.getId();
 
             // when
             AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -3,7 +3,10 @@ package com.lgcns.domain.paymentStats.service;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
@@ -19,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +34,8 @@ class PaymentStatsServiceTest extends IntegrationTest {
     @Autowired PaymentStatsRepository paymentStatsRepository;
     @Autowired PopupRepository popupRepository;
     @Autowired ManagerRepository managerRepository;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private Manager manager;
     private Manager otherManager;
@@ -95,6 +101,65 @@ class PaymentStatsServiceTest extends IntegrationTest {
             assertThatThrownBy(() -> paymentStatsService.findLatestAverageAmount(2L))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(PopupErrorCode.POPUP_UNAUTHORIZED.getMessage());
+        }
+    }
+
+    @Nested
+    class 전체_팝업_평균_구매액을_저장할_때 {
+
+        @BeforeEach
+        void setUp() {
+            manager = managerRepository.save(Manager.createManager("testManager1", "testPassword"));
+            popupRepository.saveAll(
+                    List.of(
+                            createTestPopup(manager, "popup1"),
+                            createTestPopup(manager, "popup2")));
+        }
+
+        @Test
+        void 정상적으로_통계_데이터를_저장한다() throws JsonProcessingException {
+            // given
+            String expectedResponse1 =
+                    objectMapper.writeValueAsString(
+                            Map.of("totalAverageAmount", 300_000, "todayAverageAmount", 100_000));
+
+            stubFor(
+                    get(urlEqualTo("/internal/1/average-purchase"))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(expectedResponse1)));
+
+            String expectedResponse2 =
+                    objectMapper.writeValueAsString(
+                            Map.of("totalAverageAmount", 200_000, "todayAverageAmount", 150_000));
+
+            stubFor(
+                    get(urlEqualTo("/internal/2/average-purchase"))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(expectedResponse2)));
+
+            // when
+            paymentStatsService.createPaymentStats();
+
+            // then
+            List<PaymentStats> stats = paymentStatsRepository.findAll();
+
+            assertThat(stats).hasSize(4);
+            assertThat(stats)
+                    .extracting(
+                            PaymentStats::getPopupId,
+                            PaymentStats::getAverageAmount,
+                            PaymentStats::getPeriod)
+                    .containsExactlyInAnyOrder(
+                            tuple(1L, 300_000, AveragePeriod.TOTAL),
+                            tuple(1L, 100_000, AveragePeriod.TODAY),
+                            tuple(2L, 200_000, AveragePeriod.TOTAL),
+                            tuple(2L, 150_000, AveragePeriod.TODAY));
         }
     }
 

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.paymentStats.service;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -30,209 +31,94 @@ class PaymentStatsServiceTest extends IntegrationTest {
     @Autowired PopupRepository popupRepository;
     @Autowired ManagerRepository managerRepository;
 
-    private Manager ownerManager;
+    private Manager manager;
     private Manager otherManager;
-    private Popup popup;
-
-    @BeforeEach
-    void setUp() {
-        ownerManager =
-                managerRepository.save(Manager.createManager("testManager1", "testPassword"));
-        otherManager =
-                managerRepository.save(Manager.createManager("otherManager", "testPassword"));
-
-        setAuthentication(ownerManager);
-
-        popup =
-                Popup.createPopup(
-                        ownerManager,
-                        "testPopup",
-                        "https://bucket/이미지.jpg",
-                        LocalDate.now().minusMonths(1),
-                        LocalDate.parse("2025-05-01"),
-                        LocalDateTime.of(LocalDate.now().minusMonths(1), LocalTime.of(6, 0)),
-                        LocalDateTime.parse("2025-05-01T22:00:00"),
-                        LocalTime.parse("06:00:00"),
-                        LocalTime.parse("22:00:00"),
-                        100,
-                        20,
-                        "서울특별시 강남구 테헤란로 123",
-                        "3층 A호",
-                        37.123456,
-                        127.123456);
-        popup = popupRepository.save(popup);
-
-        PaymentStats paymentStats1 =
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        10080,
-                        AveragePeriod.TOTAL,
-                        LocalDate.of(2025, 5, 2),
-                        LocalTime.of(8, 0));
-
-        PaymentStats paymentStats2 =
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        15032,
-                        AveragePeriod.TOTAL,
-                        LocalDate.of(2025, 5, 2),
-                        LocalTime.of(10, 0));
-
-        PaymentStats paymentStats3 =
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        19048,
-                        AveragePeriod.TOTAL,
-                        LocalDate.of(2025, 5, 2),
-                        LocalTime.of(12, 0));
-
-        PaymentStats paymentStats4 =
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        21794,
-                        AveragePeriod.TOTAL,
-                        LocalDate.of(2025, 5, 3),
-                        LocalTime.of(14, 0));
-
-        PaymentStats paymentStats5 =
-                paymentStatsRepository.save(
-                        PaymentStats.createPaymentStats(
-                                popup.getId(),
-                                10000,
-                                AveragePeriod.TODAY,
-                                LocalDate.now(),
-                                LocalTime.of(8, 0)));
-
-        PaymentStats paymentStats6 =
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        12900,
-                        AveragePeriod.TODAY,
-                        LocalDate.now(),
-                        LocalTime.of(10, 0));
-
-        PaymentStats paymentStats7 =
-                paymentStatsRepository.save(
-                        PaymentStats.createPaymentStats(
-                                popup.getId(),
-                                21237,
-                                AveragePeriod.TODAY,
-                                LocalDate.now(),
-                                LocalTime.of(12, 0)));
-
-        paymentStatsRepository.saveAll(
-                List.of(
-                        paymentStats1,
-                        paymentStats2,
-                        paymentStats3,
-                        paymentStats4,
-                        paymentStats5,
-                        paymentStats6,
-                        paymentStats7));
-    }
 
     @Nested
     class 평균_구매액을_조회할_때 {
 
+        @BeforeEach
+        void setUp() {
+            manager = managerRepository.save(Manager.createManager("testManager1", "testPassword"));
+            otherManager =
+                    managerRepository.save(Manager.createManager("otherManager", "testPassword"));
+
+            setAuthentication(manager);
+
+            popupRepository.save(createTestPopup(manager, "popup1"));
+            paymentStatsRepository.saveAll(
+                    List.of(
+                            createTestPaymentStats(50000, AveragePeriod.TOTAL),
+                            createTestPaymentStats(60000, AveragePeriod.TODAY)));
+        }
+
         @Test
         void 정상적으로_평균_구매액_조회에_성공한다() {
             // given
-            Long popupId = popup.getId();
+            Long popupId = 1L;
 
             // when
             AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.totalAverageAmount()).isNotNull();
-            assertThat(response.todayAverageAmount()).isNotNull();
+            assertThat(response.totalAverageAmount()).isEqualTo(50000);
+            assertThat(response.todayAverageAmount()).isEqualTo(60000);
         }
 
         @Test
-        void 존재하지_않는_팝업_ID로_조회하면_예외가_발생한다() {
-            // given
-            Long nonExistentPopupId = 9999L;
-
-            // when & then
-            assertThatThrownBy(
-                            () -> paymentStatsService.findLatestAverageAmount(nonExistentPopupId))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
-        }
-
-        @Test
-        void 다른_매니저의_팝업에_접근하면_예외가_발생한다() {
-            // given
-            Popup otherPopup =
-                    Popup.createPopup(
-                            otherManager,
-                            "testPopup2",
-                            "https://bucket/이미지2.jpg",
-                            LocalDate.now().minusMonths(1),
-                            LocalDate.parse("2025-07-16"),
-                            LocalDateTime.of(LocalDate.now().minusMonths(1), LocalTime.of(6, 0)),
-                            LocalDateTime.parse("2025-07-16T22:00:00"),
-                            LocalTime.parse("06:00:00"),
-                            LocalTime.parse("22:00:00"),
-                            200,
-                            30,
-                            "인천광역시 서구 비즈니스로 123",
-                            "16층 1601호",
-                            39.123456,
-                            129.123456);
-            otherPopup = popupRepository.save(otherPopup);
-            final Long otherPopupId = otherPopup.getId();
-
-            // when & then
-            assertThatThrownBy(() -> paymentStatsService.findLatestAverageAmount(otherPopupId))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
-        }
-
-        @Test
-        void 계산된_1인당_구매_평균값이_정확한지_확인한다() {
+        void 데이터가_존재하지_않으면_0을_반환한다() {
             // given
             paymentStatsRepository.deleteAll();
 
-            Long popupId = popup.getId();
-
-            paymentStatsRepository.save(
-                    PaymentStats.createPaymentStats(
-                            popup.getId(),
-                            5000,
-                            AveragePeriod.TOTAL,
-                            LocalDate.now().minusDays(1),
-                            LocalTime.of(12, 0)));
-
-            paymentStatsRepository.save(
-                    PaymentStats.createPaymentStats(
-                            popup.getId(),
-                            6000,
-                            AveragePeriod.TODAY,
-                            LocalDate.now(),
-                            LocalTime.of(12, 0)));
-
             // when
-            AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
-
-            // then
-            assertThat(response.totalAverageAmount()).isEqualTo(5000);
-            assertThat(response.todayAverageAmount()).isEqualTo(6000);
-        }
-
-        @Test
-        void 데이터가_없을_경우_0을_반환한다() {
-            // given
-            paymentStatsRepository.deleteAll();
-
-            Long popupId = popup.getId();
-
-            // when
-            AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
+            AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(1L);
 
             // then
             assertThat(response.totalAverageAmount()).isEqualTo(0);
             assertThat(response.todayAverageAmount()).isEqualTo(0);
         }
+
+        @Test
+        void 존재하지_않는_팝업_ID로_조회하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> paymentStatsService.findLatestAverageAmount(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PopupErrorCode.POPUP_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 다른_매니저의_팝업에_접근하면_예외가_발생한다() {
+            // given
+            popupRepository.save(createTestPopup(otherManager, "popup2"));
+
+            // when & then
+            assertThatThrownBy(() -> paymentStatsService.findLatestAverageAmount(2L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(PopupErrorCode.POPUP_UNAUTHORIZED.getMessage());
+        }
+    }
+
+    private Popup createTestPopup(Manager manager, String name) {
+        return Popup.createPopup(
+                manager,
+                name,
+                "https://bucket/이미지.jpg",
+                LocalDate.now().minusMonths(1),
+                LocalDate.parse("2025-05-01"),
+                LocalDateTime.of(LocalDate.now().minusMonths(1), LocalTime.of(6, 0)),
+                LocalDateTime.parse("2025-05-01T22:00:00"),
+                LocalTime.parse("06:00:00"),
+                LocalTime.parse("22:00:00"),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456);
+    }
+
+    private PaymentStats createTestPaymentStats(int averageAmount, AveragePeriod period) {
+        return PaymentStats.createPaymentStats(
+                1L, averageAmount, period, LocalDate.now(), LocalTime.now());
     }
 }

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.domain.paymentStats.domain.AveragePeriod;
 import com.lgcns.domain.paymentStats.domain.PaymentStats;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.domain.paymentStats.repository.PaymentStatsRepository;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class PaymentStatsServiceTest extends IntegrationTest {
+
     @Autowired PaymentStatsService paymentStatsService;
     @Autowired PaymentStatsRepository paymentStatsRepository;
     @Autowired PopupRepository popupRepository;
@@ -65,43 +67,62 @@ class PaymentStatsServiceTest extends IntegrationTest {
     }
 
     private void createTestPaymentStats() {
-        // 팝업 1 결제 통계 데이터
-        paymentStatsRepository.save(
-                PaymentStats.createPaymentStats(
-                        popup.getId(), LocalDate.of(2025, 5, 2), LocalTime.of(8, 0), 1250000, 124));
         paymentStatsRepository.save(
                 PaymentStats.createPaymentStats(
                         popup.getId(),
+                        10080,
+                        AveragePeriod.TOTAL,
                         LocalDate.of(2025, 5, 2),
-                        LocalTime.of(10, 0),
-                        2345000,
-                        156));
-        paymentStatsRepository.save(
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        LocalDate.of(2025, 5, 2),
-                        LocalTime.of(12, 0),
-                        3560000,
-                        187));
-        paymentStatsRepository.save(
-                PaymentStats.createPaymentStats(
-                        popup.getId(),
-                        LocalDate.of(2025, 5, 3),
-                        LocalTime.of(14, 0),
-                        4250000,
-                        195));
+                        LocalTime.of(8, 0)));
 
-        // 오늘 날짜로 가정한 데이터 추가
+        paymentStatsRepository.save(
+                PaymentStats.createPaymentStats(
+                        popup.getId(),
+                        15032,
+                        AveragePeriod.TOTAL,
+                        LocalDate.of(2025, 5, 2),
+                        LocalTime.of(10, 0)));
+
+        paymentStatsRepository.save(
+                PaymentStats.createPaymentStats(
+                        popup.getId(),
+                        19048,
+                        AveragePeriod.TOTAL,
+                        LocalDate.of(2025, 5, 2),
+                        LocalTime.of(12, 0)));
+
+        paymentStatsRepository.save(
+                PaymentStats.createPaymentStats(
+                        popup.getId(),
+                        21794,
+                        AveragePeriod.TOTAL,
+                        LocalDate.of(2025, 5, 3),
+                        LocalTime.of(14, 0)));
+
         LocalDate today = LocalDate.now();
         paymentStatsRepository.save(
                 PaymentStats.createPaymentStats(
-                        popup.getId(), today, LocalTime.of(8, 0), 980000, 98));
+                        popup.getId(),
+                        10000,
+                        AveragePeriod.TODAY,
+                        today,
+                        LocalTime.of(8, 0))); // 980000 / 98
+
         paymentStatsRepository.save(
                 PaymentStats.createPaymentStats(
-                        popup.getId(), today, LocalTime.of(10, 0), 1870000, 145));
+                        popup.getId(),
+                        12900,
+                        AveragePeriod.TODAY,
+                        today,
+                        LocalTime.of(10, 0))); // 1870000 / 145
+
         paymentStatsRepository.save(
                 PaymentStats.createPaymentStats(
-                        popup.getId(), today, LocalTime.of(12, 0), 4120000, 194));
+                        popup.getId(),
+                        21237,
+                        AveragePeriod.TODAY,
+                        today,
+                        LocalTime.of(12, 0))); // 4120000 / 194
     }
 
     @Nested
@@ -115,7 +136,7 @@ class PaymentStatsServiceTest extends IntegrationTest {
             Long popupId = popup.getId();
 
             // when
-            AverageAmountResponse response = paymentStatsService.getPaymentAverages(popupId);
+            AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
 
             // then
             assertThat(response).isNotNull();
@@ -130,7 +151,8 @@ class PaymentStatsServiceTest extends IntegrationTest {
             Long nonExistentPopupId = 9999L;
 
             // when & then
-            assertThatThrownBy(() -> paymentStatsService.getPaymentAverages(nonExistentPopupId))
+            assertThatThrownBy(
+                            () -> paymentStatsService.findLatestAverageAmount(nonExistentPopupId))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
         }
@@ -160,7 +182,7 @@ class PaymentStatsServiceTest extends IntegrationTest {
             final Long otherPopupId = otherPopup.getId();
 
             // when & then
-            assertThatThrownBy(() -> paymentStatsService.getPaymentAverages(otherPopupId))
+            assertThatThrownBy(() -> paymentStatsService.findLatestAverageAmount(otherPopupId))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
         }
@@ -181,14 +203,18 @@ class PaymentStatsServiceTest extends IntegrationTest {
             // 초기
             paymentStatsRepository.save(
                     PaymentStats.createPaymentStats(
-                            popup.getId(), today.minusDays(1), LocalTime.of(12, 0), 40000, 10));
-            // 오늘
+                            popup.getId(),
+                            5000,
+                            AveragePeriod.TOTAL,
+                            today.minusDays(1),
+                            LocalTime.of(12, 0)));
+
             paymentStatsRepository.save(
                     PaymentStats.createPaymentStats(
-                            popup.getId(), today, LocalTime.of(12, 0), 60000, 10));
+                            popup.getId(), 6000, AveragePeriod.TODAY, today, LocalTime.of(12, 0)));
 
             // when
-            AverageAmountResponse response = paymentStatsService.getPaymentAverages(popupId);
+            AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
 
             // then
             assertThat(response.totalAverageAmount()).isEqualTo(5000);
@@ -203,7 +229,7 @@ class PaymentStatsServiceTest extends IntegrationTest {
             paymentStatsRepository.deleteAll();
 
             // when
-            AverageAmountResponse response = paymentStatsService.getPaymentAverages(popupId);
+            AverageAmountResponse response = paymentStatsService.findLatestAverageAmount(popupId);
 
             // then
             assertThat(response.totalAverageAmount()).isEqualTo(0);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,3 +23,8 @@ reservation:
   service:
     name: reservations
     url: http://localhost:${wiremock.server.port}
+
+payment:
+  service:
+    name: payments
+    url: http://localhost:${wiremock.server.port}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-297]

---
## 📌 작업 내용 및 특이사항

- 결제 서비스 Internal API를 호출해 팝업별 1인 평균 구매액(totalAverageAmount, todayAverageAmount)을 조회하도록 수정했습니다.
- 해당 로직은 매 시간마다 실행되는 스케줄러에서 전체 팝업을 대상으로 수행되며, 실시간 조회 대신 데이터를 DB에 저장해두는 방식으로 설계했습니다.
- 모든 팝업에 대해 평균값을 조회하고 벌크 연산으로 insert 쿼리를 최적화했습니다.
- 호출 시점 기준의 평균 값을 payment_stats 테이블에 새로 삽입하며, 이력을 남기는 것이 목적이기 때문에 update가 아닌 insert로 처리했습니다.
- 관리자가 조회할 때마다 결제 서비스에 API를 호출하는 구조는 네트워크 부하가 크기 때문에, 스케줄링을 통해 미리 저장된 값을 활용할 수 있도록 했습니다.
- 기존에 작성되어 있던 테스트 코드 전반적으로 리팩토링 진행하였습니다.

---
## 📚 참고사항

- 스케줄러는 단순히 서비스 레이어를 호출하도록 구성해주세요. 스케줄러는 단순 트리거만 하는 게 이상적입니다!

[LCR-297]: https://lgcns-retail.atlassian.net/browse/LCR-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ