### PR TITLE
feat: 팝업별 구매 전환율 통계 스케줄링 저장 및 조회 로직 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/conversionStats/domain/ConversionStats.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/domain/ConversionStats.java
@@ -1,6 +1,5 @@
 package com.lgcns.domain.conversionStats.domain;
 
-import com.lgcns.global.model.BaseTimeEntity;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -12,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ConversionStats extends BaseTimeEntity {
+public class ConversionStats {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/lgcns/domain/conversionStats/domain/ConversionStats.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/domain/ConversionStats.java
@@ -1,0 +1,68 @@
+package com.lgcns.domain.conversionStats.domain;
+
+import com.lgcns.global.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConversionStats extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "conversion_stats_id")
+    private Long id;
+
+    private Long popupId;
+    private Long itemId;
+
+    private int interestedCount;
+    private int buyerCount;
+    private int conversionRate;
+
+    private LocalDate analyzedDate;
+    private LocalTime analyzedTime;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public ConversionStats(
+            Long popupId,
+            Long itemId,
+            int interestedCount,
+            int buyerCount,
+            int conversionRate,
+            LocalDate analyzedDate,
+            LocalTime analyzedTime) {
+        this.popupId = popupId;
+        this.itemId = itemId;
+        this.interestedCount = interestedCount;
+        this.buyerCount = buyerCount;
+        this.conversionRate = conversionRate;
+        this.analyzedDate = analyzedDate;
+        this.analyzedTime = analyzedTime;
+    }
+
+    public static ConversionStats createConversionStats(
+            Long popupId,
+            Long itemId,
+            int interestedCount,
+            int buyerCount,
+            int conversionRate,
+            LocalDate analyzedDate,
+            LocalTime analyzedTime) {
+        return ConversionStats.builder()
+                .popupId(popupId)
+                .itemId(itemId)
+                .interestedCount(interestedCount)
+                .buyerCount(buyerCount)
+                .conversionRate(conversionRate)
+                .analyzedDate(analyzedDate)
+                .analyzedTime(analyzedTime)
+                .build();
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/dto/response/ConversionItem.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/dto/response/ConversionItem.java
@@ -1,0 +1,9 @@
+package com.lgcns.domain.conversionStats.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ConversionItem(
+        @Schema(description = "상품명", example = "POSTER SET") String name,
+        @Schema(description = "관심자 수", example = "200") Integer interested,
+        @Schema(description = "구매자 수", example = "100") Integer purchased,
+        @Schema(description = "구매 전환율(%)", example = "50") Integer conversionRatio) {}

--- a/src/main/java/com/lgcns/domain/conversionStats/dto/response/ConversionItemsResponse.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/dto/response/ConversionItemsResponse.java
@@ -1,0 +1,12 @@
+package com.lgcns.domain.conversionStats.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record ConversionItemsResponse(
+        @Schema(description = "구매 전환율 하위 상품 TOP 6") List<ConversionItem> low,
+        @Schema(description = "구매 전환율 상위 상품 TOP 6") List<ConversionItem> high) {
+    public static ConversionItemsResponse of(List<ConversionItem> low, List<ConversionItem> high) {
+        return new ConversionItemsResponse(low, high);
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/dto/response/ItemBuyerCountResponse.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/dto/response/ItemBuyerCountResponse.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.conversionStats.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ItemBuyerCountResponse(
+        @Schema(description = "상품 ID", example = "1") Long itemId,
+        @Schema(description = "구매자 수", example = "50") Integer buyerCount) {}

--- a/src/main/java/com/lgcns/domain/conversionStats/externalApi/ConversionStatsController.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/externalApi/ConversionStatsController.java
@@ -1,0 +1,26 @@
+package com.lgcns.domain.conversionStats.externalApi;
+
+import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
+import com.lgcns.domain.conversionStats.service.ConversionStatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/popups/{popupId}/dashboard")
+@RequiredArgsConstructor
+@Tag(name = "12. 구매전환율 분석 API", description = "구매전환율 분석 관련 API 입니다.")
+public class ConversionStatsController {
+
+    private final ConversionStatsService conversionStatsService;
+
+    @GetMapping("/conversion-ratio")
+    @Operation(summary = "구매전환율 조회", description = "특정 상품에 대한 관심자 수와 구매자 수의 비율을 계산하여 구매전환율을 조회합니다.")
+    public ConversionItemsResponse conversionItemsFind(@PathVariable Long popupId) {
+        return conversionStatsService.findConversionItems(popupId);
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepository.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepository.java
@@ -1,0 +1,7 @@
+package com.lgcns.domain.conversionStats.repository;
+
+import com.lgcns.domain.conversionStats.domain.ConversionStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversionStatsRepository
+        extends JpaRepository<ConversionStats, Long>, ConversionStatsRepositoryCustom {}

--- a/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.conversionStats.repository;
 
+import com.lgcns.domain.conversionStats.domain.ConversionStats;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
 import java.util.List;
 
@@ -7,4 +8,6 @@ public interface ConversionStatsRepositoryCustom {
     List<ConversionItem> findTop6LowConversionItemsByPopupId(Long popupId);
 
     List<ConversionItem> findTop6HighConversionItemsByPopupId(Long popupId);
+
+    void bulkInsertConversionStats(List<ConversionStats> statsList);
 }

--- a/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.lgcns.domain.conversionStats.repository;
+
+import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
+import java.util.List;
+
+public interface ConversionStatsRepositoryCustom {
+    List<ConversionItem> findTop6LowConversionItemsByPopupId(Long popupId);
+
+    List<ConversionItem> findTop6HighConversionItemsByPopupId(Long popupId);
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.lgcns.domain.conversionStats.repository;
+
+import static com.lgcns.domain.conversionStats.domain.QConversionStats.conversionStats;
+import static com.lgcns.domain.item.domain.QItem.item;
+
+import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ConversionStatsRepositoryImpl implements ConversionStatsRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ConversionItem> findTop6LowConversionItemsByPopupId(Long popupId) {
+        return fetchTop6ConversionItems(popupId, SortDirection.ASC);
+    }
+
+    @Override
+    public List<ConversionItem> findTop6HighConversionItemsByPopupId(Long popupId) {
+        return fetchTop6ConversionItems(popupId, SortDirection.DESC);
+    }
+
+    private List<ConversionItem> fetchTop6ConversionItems(Long popupId, SortDirection direction) {
+        OrderSpecifier<Integer> orderSpecifier =
+                (direction == SortDirection.DESC)
+                        ? conversionStats.conversionRate.desc()
+                        : conversionStats.conversionRate.asc();
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ConversionItem.class,
+                                item.name,
+                                conversionStats.interestedCount,
+                                conversionStats.buyerCount,
+                                conversionStats.conversionRate))
+                .from(conversionStats)
+                .join(item)
+                .on(item.id.eq(conversionStats.itemId))
+                .where(
+                        conversionStats.popupId.eq(popupId),
+                        conversionStats.analyzedDate.eq(LocalDate.now()))
+                .orderBy(orderSpecifier)
+                .limit(6)
+                .fetch();
+    }
+
+    private enum SortDirection {
+        ASC,
+        DESC
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryImpl.java
@@ -3,10 +3,12 @@ package com.lgcns.domain.conversionStats.repository;
 import static com.lgcns.domain.conversionStats.domain.QConversionStats.conversionStats;
 import static com.lgcns.domain.item.domain.QItem.item;
 
+import com.lgcns.domain.conversionStats.domain.ConversionStats;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ConversionStatsRepositoryImpl implements ConversionStatsRepositoryCustom {
 
+    private EntityManager em;
     private final JPAQueryFactory queryFactory;
 
     @Override
@@ -26,6 +29,44 @@ public class ConversionStatsRepositoryImpl implements ConversionStatsRepositoryC
     @Override
     public List<ConversionItem> findTop6HighConversionItemsByPopupId(Long popupId) {
         return fetchTop6ConversionItems(popupId, SortDirection.DESC);
+    }
+
+    @Override
+    public void bulkInsertConversionStats(List<ConversionStats> statsList) {
+        if (statsList.isEmpty()) return;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(
+                "INSERT INTO conversion_stats (popup_id, item_id, interested_count, buyer_count, conversion_rate, analyzed_date, analyzed_time) VALUES ");
+
+        for (int i = 0; i < statsList.size(); i++) {
+            ConversionStats cs = statsList.get(i);
+            sb.append("(")
+                    .append(cs.getPopupId())
+                    .append(", ")
+                    .append(cs.getItemId())
+                    .append(", ")
+                    .append("'")
+                    .append(cs.getInterestedCount())
+                    .append("', ")
+                    .append("'")
+                    .append(cs.getBuyerCount())
+                    .append("', ")
+                    .append("'")
+                    .append(cs.getConversionRate())
+                    .append("', ")
+                    .append("'")
+                    .append(cs.getAnalyzedDate())
+                    .append("', ")
+                    .append("'")
+                    .append(cs.getAnalyzedTime())
+                    .append("'")
+                    .append(")");
+
+            if (i < statsList.size() - 1) sb.append(", ");
+        }
+
+        em.createNativeQuery(sb.toString()).executeUpdate();
     }
 
     private List<ConversionItem> fetchTop6ConversionItems(Long popupId, SortDirection direction) {

--- a/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/repository/ConversionStatsRepositoryImpl.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ConversionStatsRepositoryImpl implements ConversionStatsRepositoryCustom {
 
-    private EntityManager em;
+    private final EntityManager em;
     private final JPAQueryFactory queryFactory;
 
     @Override

--- a/src/main/java/com/lgcns/domain/conversionStats/scheduler/ConversionStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/scheduler/ConversionStatsScheduler.java
@@ -1,0 +1,18 @@
+package com.lgcns.domain.conversionStats.scheduler;
+
+import com.lgcns.domain.conversionStats.service.ConversionStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ConversionStatsScheduler {
+
+    private final ConversionStatsService conversionStatsService;
+
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void createConversionStats() {
+        conversionStatsService.createConversionStats();
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
@@ -1,64 +1,7 @@
 package com.lgcns.domain.conversionStats.service;
 
-// import com.lgcns.domain.conversionStats.domain.Interest;
+import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
 
-import com.lgcns.domain.conversionStats.domain.PopupEvent;
-import com.lgcns.domain.manager.domain.Manager;
-import com.lgcns.domain.popup.domain.Popup;
-import com.lgcns.domain.popup.exception.PopupErrorCode;
-import com.lgcns.domain.popup.repository.PopupRepository;
-import com.lgcns.global.error.exception.CustomException;
-import com.lgcns.global.util.ManagerUtil;
-import com.lgcns.infra.dynamodb.DynamoDbProperties;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
-import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
-import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
-
-@Service
-@RequiredArgsConstructor
-@Transactional
-@Slf4j
-public class ConversionStatsService {
-
-    private final ManagerUtil managerUtil;
-    private final PopupRepository popupRepository;
-    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
-    private final DynamoDbProperties dynamoDbProperties;
-
-    private Long countInterestedUsersByItem(Long popupId, Long targetItemId) {
-        final Manager currentManager = managerUtil.getCurrentManager();
-        final Popup popup = findPopupById(popupId);
-
-        validatePopupOwnership(currentManager, popup);
-
-        DynamoDbTable<PopupEvent> table =
-                dynamoDbEnhancedClient.table(
-                        dynamoDbProperties.tableName(), TableSchema.fromBean(PopupEvent.class));
-
-        QueryConditional condition =
-                QueryConditional.keyEqualTo(
-                        Key.builder().partitionValue(popupId.toString()).build());
-
-        return table.query(r -> r.queryConditional(condition)).items().stream()
-                .filter(i -> i.getItemId().equals(targetItemId))
-                .count();
-    }
-
-    private Popup findPopupById(Long popupId) {
-        return popupRepository
-                .findById(popupId)
-                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
-    }
-
-    private void validatePopupOwnership(Manager manager, Popup popup) {
-        if (!popup.getManager().equals(manager)) {
-            throw new CustomException(PopupErrorCode.POPUP_UNAUTHORIZED);
-        }
-    }
+public interface ConversionStatsService {
+    ConversionItemsResponse findConversionItems(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsService.java
@@ -4,4 +4,6 @@ import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
 
 public interface ConversionStatsService {
     ConversionItemsResponse findConversionItems(Long popupId);
+
+    void createConversionStats();
 }

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
@@ -1,7 +1,6 @@
 package com.lgcns.domain.conversionStats.service;
 
 import com.lgcns.domain.conversionStats.domain.ConversionStats;
-import com.lgcns.domain.conversionStats.domain.PopupEvent;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
 import com.lgcns.domain.conversionStats.dto.response.ItemBuyerCountResponse;
@@ -13,7 +12,8 @@ import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import com.lgcns.infra.client.payment.PaymentServiceClient;
-import com.lgcns.infra.dynamodb.DynamoDbProperties;
+import com.lgcns.infra.dynamodb.conversionStats.DynamoDbInterestedUserCounter;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -22,11 +22,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.Key;
-import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
-import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 
 @Slf4j
 @Service
@@ -38,8 +33,7 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
     private final PopupRepository popupRepository;
     private final ConversionStatsRepository conversionStatsRepository;
     private final PaymentServiceClient paymentServiceClient;
-    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
-    private final DynamoDbProperties dynamoDbProperties;
+    private final DynamoDbInterestedUserCounter dynamoDbInterestedUserCounter;
 
     @Override
     @Transactional(readOnly = true)
@@ -69,7 +63,7 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
 
                 for (ItemBuyerCountResponse count : counts) {
                     int interestedCount =
-                            countInterestedUsersByItem(popupId, count.itemId()).intValue();
+                            (int) dynamoDbInterestedUserCounter.countInterestedUsers(popupId, count.itemId());
                     int buyerCount = count.buyerCount();
                     int conversionRate = Math.round((float) buyerCount / interestedCount * 100);
 
@@ -94,20 +88,6 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
         if (!statsList.isEmpty()) {
             conversionStatsRepository.bulkInsertConversionStats(statsList);
         }
-    }
-
-    private Long countInterestedUsersByItem(Long popupId, Long targetItemId) {
-        DynamoDbTable<PopupEvent> table =
-                dynamoDbEnhancedClient.table(
-                        dynamoDbProperties.tableName(), TableSchema.fromBean(PopupEvent.class));
-
-        QueryConditional condition =
-                QueryConditional.keyEqualTo(
-                        Key.builder().partitionValue(popupId.toString()).build());
-
-        return table.query(r -> r.queryConditional(condition)).items().stream()
-                .filter(i -> i.getItemId().equals(targetItemId))
-                .count();
     }
 
     private Popup findPopupById(Long popupId) {

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
@@ -13,7 +13,6 @@ import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import com.lgcns.infra.client.payment.PaymentServiceClient;
 import com.lgcns.infra.dynamodb.conversionStats.DynamoDbInterestedUserCounter;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -63,7 +62,9 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
 
                 for (ItemBuyerCountResponse count : counts) {
                     int interestedCount =
-                            (int) dynamoDbInterestedUserCounter.countInterestedUsers(popupId, count.itemId());
+                            (int)
+                                    dynamoDbInterestedUserCounter.countInterestedUsers(
+                                            popupId, count.itemId());
                     int buyerCount = count.buyerCount();
                     int conversionRate = Math.round((float) buyerCount / interestedCount * 100);
 

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
@@ -1,8 +1,10 @@
 package com.lgcns.domain.conversionStats.service;
 
+import com.lgcns.domain.conversionStats.domain.ConversionStats;
 import com.lgcns.domain.conversionStats.domain.PopupEvent;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
+import com.lgcns.domain.conversionStats.dto.response.ItemBuyerCountResponse;
 import com.lgcns.domain.conversionStats.repository.ConversionStatsRepository;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
@@ -10,9 +12,14 @@ import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
+import com.lgcns.infra.client.payment.PaymentServiceClient;
 import com.lgcns.infra.dynamodb.DynamoDbProperties;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
@@ -21,6 +28,7 @@ import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -29,10 +37,12 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
     private final ManagerUtil managerUtil;
     private final PopupRepository popupRepository;
     private final ConversionStatsRepository conversionStatsRepository;
+    private final PaymentServiceClient paymentServiceClient;
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
     private final DynamoDbProperties dynamoDbProperties;
 
     @Override
+    @Transactional(readOnly = true)
     public ConversionItemsResponse findConversionItems(Long popupId) {
         final Manager currentManager = managerUtil.getCurrentManager();
         final Popup popup = findPopupById(popupId);
@@ -44,6 +54,46 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
                 conversionStatsRepository.findTop6HighConversionItemsByPopupId(popupId);
 
         return new ConversionItemsResponse(low, high);
+    }
+
+    @Override
+    public void createConversionStats() {
+        List<Long> popupIds = popupRepository.findAllPopupIds();
+
+        List<ConversionStats> statsList = new ArrayList<>();
+
+        for (Long popupId : popupIds) {
+            try {
+                List<ItemBuyerCountResponse> counts =
+                        paymentServiceClient.countItemBuyerByPopupId(popupId);
+
+                for (ItemBuyerCountResponse count : counts) {
+                    int interestedCount =
+                            countInterestedUsersByItem(popupId, count.itemId()).intValue();
+                    int buyerCount = count.buyerCount();
+                    int conversionRate = count.buyerCount() / interestedCount * 100;
+
+                    ConversionStats stats =
+                            ConversionStats.createConversionStats(
+                                    popupId,
+                                    count.itemId(),
+                                    interestedCount,
+                                    buyerCount,
+                                    conversionRate,
+                                    LocalDate.now(),
+                                    LocalTime.now());
+
+                    statsList.add(stats);
+                }
+
+            } catch (Exception e) {
+                log.warn("Failed to prepare conversion stats for popupId: {}", popupId, e);
+            }
+        }
+
+        if (!statsList.isEmpty()) {
+            conversionStatsRepository.bulkInsertConversionStats(statsList);
+        }
     }
 
     private Long countInterestedUsersByItem(Long popupId, Long targetItemId) {

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
@@ -1,0 +1,74 @@
+package com.lgcns.domain.conversionStats.service;
+
+import com.lgcns.domain.conversionStats.domain.PopupEvent;
+import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
+import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
+import com.lgcns.domain.conversionStats.repository.ConversionStatsRepository;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.popup.domain.Popup;
+import com.lgcns.domain.popup.exception.PopupErrorCode;
+import com.lgcns.domain.popup.repository.PopupRepository;
+import com.lgcns.global.error.exception.CustomException;
+import com.lgcns.global.util.ManagerUtil;
+import com.lgcns.infra.dynamodb.DynamoDbProperties;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ConversionStatsServiceImpl implements ConversionStatsService {
+
+    private final ManagerUtil managerUtil;
+    private final PopupRepository popupRepository;
+    private final ConversionStatsRepository conversionStatsRepository;
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final DynamoDbProperties dynamoDbProperties;
+
+    @Override
+    public ConversionItemsResponse findConversionItems(Long popupId) {
+        final Manager currentManager = managerUtil.getCurrentManager();
+        final Popup popup = findPopupById(popupId);
+        validatePopupOwnership(currentManager, popup);
+
+        List<ConversionItem> low =
+                conversionStatsRepository.findTop6LowConversionItemsByPopupId(popupId);
+        List<ConversionItem> high =
+                conversionStatsRepository.findTop6HighConversionItemsByPopupId(popupId);
+
+        return new ConversionItemsResponse(low, high);
+    }
+
+    private Long countInterestedUsersByItem(Long popupId, Long targetItemId) {
+        DynamoDbTable<PopupEvent> table =
+                dynamoDbEnhancedClient.table(
+                        dynamoDbProperties.tableName(), TableSchema.fromBean(PopupEvent.class));
+
+        QueryConditional condition =
+                QueryConditional.keyEqualTo(
+                        Key.builder().partitionValue(popupId.toString()).build());
+
+        return table.query(r -> r.queryConditional(condition)).items().stream()
+                .filter(i -> i.getItemId().equals(targetItemId))
+                .count();
+    }
+
+    private Popup findPopupById(Long popupId) {
+        return popupRepository
+                .findById(popupId)
+                .orElseThrow(() -> new CustomException(PopupErrorCode.POPUP_NOT_FOUND));
+    }
+
+    private void validatePopupOwnership(Manager manager, Popup popup) {
+        if (!popup.getManager().equals(manager)) {
+            throw new CustomException(PopupErrorCode.POPUP_UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
@@ -71,7 +71,7 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
                     int interestedCount =
                             countInterestedUsersByItem(popupId, count.itemId()).intValue();
                     int buyerCount = count.buyerCount();
-                    int conversionRate = count.buyerCount() / interestedCount * 100;
+                    int conversionRate = Math.round((float) buyerCount / interestedCount * 100);
 
                     ConversionStats stats =
                             ConversionStats.createConversionStats(

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
@@ -1,7 +1,6 @@
 package com.lgcns.domain.paymentStats.service;
 
 import com.lgcns.domain.manager.domain.Manager;
-import com.lgcns.domain.paymentStats.client.PaymentServiceClient;
 import com.lgcns.domain.paymentStats.domain.AveragePeriod;
 import com.lgcns.domain.paymentStats.domain.PaymentStats;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
@@ -11,6 +10,7 @@ import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
+import com.lgcns.infra.client.payment.PaymentServiceClient;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;

--- a/src/main/java/com/lgcns/infra/client/payment/PaymentServiceClient.java
+++ b/src/main/java/com/lgcns/infra/client/payment/PaymentServiceClient.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain.paymentStats.client;
+package com.lgcns.infra.client.payment;
 
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.global.config.feign.FeignConfig;

--- a/src/main/java/com/lgcns/infra/client/payment/PaymentServiceClient.java
+++ b/src/main/java/com/lgcns/infra/client/payment/PaymentServiceClient.java
@@ -1,7 +1,9 @@
 package com.lgcns.infra.client.payment;
 
+import com.lgcns.domain.conversionStats.dto.response.ItemBuyerCountResponse;
 import com.lgcns.domain.paymentStats.dto.response.AverageAmountResponse;
 import com.lgcns.global.config.feign.FeignConfig;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,4 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface PaymentServiceClient {
     @GetMapping("/internal/{popupId}/average-purchase")
     AverageAmountResponse findAverageAmount(@PathVariable(name = "popupId") Long popupId);
+
+    @GetMapping("/internal/{popupId}/buyer-counts")
+    List<ItemBuyerCountResponse> countItemBuyerByPopupId(@PathVariable Long popupId);
 }

--- a/src/main/java/com/lgcns/infra/dynamodb/conversionStats/DynamoDbInterestedUserCounter.java
+++ b/src/main/java/com/lgcns/infra/dynamodb/conversionStats/DynamoDbInterestedUserCounter.java
@@ -1,0 +1,32 @@
+package com.lgcns.infra.dynamodb.conversionStats;
+
+import com.lgcns.infra.dynamodb.DynamoDbProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+
+@Component
+@RequiredArgsConstructor
+public class DynamoDbInterestedUserCounter {
+
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient;
+    private final DynamoDbProperties dynamoDbProperties;
+
+    public long countInterestedUsers(Long popupId, Long targetItemId) {
+        DynamoDbTable<PopupEvent> table =
+                dynamoDbEnhancedClient.table(
+                        dynamoDbProperties.tableName(), TableSchema.fromBean(PopupEvent.class));
+
+        QueryConditional condition =
+                QueryConditional.keyEqualTo(
+                        Key.builder().partitionValue(popupId.toString()).build());
+
+        return table.query(r -> r.queryConditional(condition)).items().stream()
+                .filter(i -> i.getItemId().equals(targetItemId))
+                .count();
+    }
+}

--- a/src/main/java/com/lgcns/infra/dynamodb/conversionStats/PopupEvent.java
+++ b/src/main/java/com/lgcns/infra/dynamodb/conversionStats/PopupEvent.java
@@ -1,4 +1,4 @@
-package com.lgcns.domain.conversionStats.domain;
+package com.lgcns.infra.dynamodb.conversionStats;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;

--- a/src/main/resources/db/migration/V16__create_conversion_stats_table.sql
+++ b/src/main/resources/db/migration/V16__create_conversion_stats_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE conversion_stats (
+                               conversion_stats_id	BIGINT	AUTO_INCREMENT PRIMARY KEY,
+                               popup_id	BIGINT	NOT NULL,
+                               item_id	BIGINT	NOT NULL,
+                               interested_count INT NOT NULL,
+                               buyer_count INT NOT NULL,
+                               conversion_rate INT NOT NULL,
+                               analyzed_date	DATE	NOT NULL,
+                               analyzed_time	TIME	NOT NULL,
+                               created_at DATETIME NOT NULL,
+                               updated_at DATETIME
+);
+

--- a/src/main/resources/db/migration/V16__create_conversion_stats_table.sql
+++ b/src/main/resources/db/migration/V16__create_conversion_stats_table.sql
@@ -6,8 +6,6 @@ CREATE TABLE conversion_stats (
                                buyer_count INT NOT NULL,
                                conversion_rate INT NOT NULL,
                                analyzed_date	DATE	NOT NULL,
-                               analyzed_time	TIME	NOT NULL,
-                               created_at DATETIME NOT NULL,
-                               updated_at DATETIME
+                               analyzed_time	TIME	NOT NULL
 );
 

--- a/src/test/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceTest.java
@@ -2,12 +2,17 @@ package com.lgcns.domain.conversionStats.service;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lgcns.IntegrationTest;
 import com.lgcns.domain.conversionStats.domain.ConversionStats;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
 import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
+import com.lgcns.domain.conversionStats.dto.response.ItemBuyerCountResponse;
 import com.lgcns.domain.conversionStats.repository.ConversionStatsRepository;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.repository.ItemRepository;
@@ -15,6 +20,7 @@ import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.repository.PopupRepository;
+import com.lgcns.infra.dynamodb.conversionStats.DynamoDbInterestedUserCounter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -26,6 +32,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.Commit;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class ConversionStatsServiceTest extends IntegrationTest {
 
@@ -34,6 +41,8 @@ class ConversionStatsServiceTest extends IntegrationTest {
     @Autowired ItemRepository itemRepository;
     @Autowired PopupRepository popupRepository;
     @Autowired ManagerRepository managerRepository;
+
+    @MockitoBean DynamoDbInterestedUserCounter dynamoDbInterestedUserCounter;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -116,6 +125,101 @@ class ConversionStatsServiceTest extends IntegrationTest {
             // then
             assertThat(response.low()).isEmpty();
             assertThat(response.high()).isEmpty();
+        }
+    }
+
+    @Nested
+    class 전체_팝업_구매_전환율을_저장할_때 {
+
+        @BeforeEach
+        void setUp() {
+            manager = managerRepository.save(Manager.createManager("testManager", "testPassword"));
+            popupRepository.saveAll(
+                    List.of(
+                            createTestPopup(manager, "popup1"),
+                            createTestPopup(manager, "popup2")));
+
+            for (long i = 1; i <= 3; i++) {
+                itemRepository.save(
+                        Item.createItem(
+                                popupRepository.findById(1L).orElseThrow(),
+                                "Item " + i,
+                                "https://bucket/item" + i + ".jpg",
+                                10000,
+                                100,
+                                10,
+                                "desc" + i));
+            }
+
+            for (long i = 4; i <= 6; i++) {
+                itemRepository.save(
+                        Item.createItem(
+                                popupRepository.findById(2L).orElseThrow(),
+                                "Item " + i,
+                                "https://bucket/item" + i + ".jpg",
+                                10000,
+                                100,
+                                10,
+                                "desc" + i));
+            }
+        }
+
+        @Test
+        void 정상적으로_통계_데이터를_저장한다() throws JsonProcessingException {
+            // given
+            when(dynamoDbInterestedUserCounter.countInterestedUsers(anyLong(), anyLong()))
+                    .thenReturn(150L);
+
+            String expectedResponse1 =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    new ItemBuyerCountResponse(1L, 100),
+                                    new ItemBuyerCountResponse(2L, 80),
+                                    new ItemBuyerCountResponse(3L, 60)));
+
+            stubFor(
+                    get(urlEqualTo("/internal/1/buyer-counts"))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(expectedResponse1)));
+
+            String expectedResponse2 =
+                    objectMapper.writeValueAsString(
+                            List.of(
+                                    new ItemBuyerCountResponse(4L, 40),
+                                    new ItemBuyerCountResponse(5L, 20),
+                                    new ItemBuyerCountResponse(6L, 10)));
+
+            stubFor(
+                    get(urlEqualTo("/internal/2/buyer-counts"))
+                            .willReturn(
+                                    aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/json")
+                                            .withBody(expectedResponse2)));
+
+            // when
+            conversionStatsService.createConversionStats();
+
+            // then
+            List<ConversionStats> stats = conversionStatsRepository.findAll();
+
+            assertThat(stats).hasSize(6);
+
+            assertThat(stats)
+                    .extracting(
+                            ConversionStats::getPopupId,
+                            ConversionStats::getItemId,
+                            ConversionStats::getBuyerCount)
+                    .containsExactlyInAnyOrder(
+                            tuple(1L, 1L, 100),
+                            tuple(1L, 2L, 80),
+                            tuple(1L, 3L, 60),
+                            tuple(2L, 4L, 40),
+                            tuple(2L, 5L, 20),
+                            tuple(2L, 6L, 10));
         }
     }
 

--- a/src/test/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceTest.java
@@ -1,0 +1,140 @@
+package com.lgcns.domain.conversionStats.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.IntegrationTest;
+import com.lgcns.domain.conversionStats.domain.ConversionStats;
+import com.lgcns.domain.conversionStats.dto.response.ConversionItem;
+import com.lgcns.domain.conversionStats.dto.response.ConversionItemsResponse;
+import com.lgcns.domain.conversionStats.repository.ConversionStatsRepository;
+import com.lgcns.domain.item.domain.Item;
+import com.lgcns.domain.item.repository.ItemRepository;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.domain.popup.domain.Popup;
+import com.lgcns.domain.popup.repository.PopupRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.Commit;
+
+class ConversionStatsServiceTest extends IntegrationTest {
+
+    @Autowired ConversionStatsService conversionStatsService;
+    @Autowired ConversionStatsRepository conversionStatsRepository;
+    @Autowired ItemRepository itemRepository;
+    @Autowired PopupRepository popupRepository;
+    @Autowired ManagerRepository managerRepository;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private Manager manager;
+
+    @Nested
+    class 구매_전환율을_조회할_때 {
+
+        @BeforeEach
+        void setUp() {
+            manager = managerRepository.save(Manager.createManager("testManager", "testPassword"));
+
+            setAuthentication(manager);
+
+            Popup popup = popupRepository.save(createTestPopup(manager, "popup1"));
+
+            List<Item> items = new ArrayList<>();
+            for (int i = 1; i <= 24; i++) {
+                items.add(
+                        Item.createItem(
+                                popup,
+                                "ITEM " + i,
+                                "https://bucket/item" + i + ".jpg",
+                                10000,
+                                100,
+                                10,
+                                "a" + i));
+            }
+            itemRepository.saveAll(items);
+
+            List<ConversionStats> stats = new ArrayList<>();
+            for (long i = 1; i <= 24; i++) {
+                int interested = 100 + (int) (Math.random() * 100);
+                int buyer = (int) (Math.random() * interested);
+                int rate = interested == 0 ? 0 : (buyer * 100) / interested;
+
+                stats.add(
+                        ConversionStats.createConversionStats(
+                                1L, i, interested, buyer, rate, LocalDate.now(), LocalTime.now()));
+            }
+            conversionStatsRepository.saveAll(stats);
+        }
+
+        @Test
+        @Commit
+        void 정상적으로_구매_전환율_조회에_성공한다() {
+            // given
+            Long popupId = 1L;
+
+            // when
+            System.out.println("now from service: " + LocalDate.now());
+            conversionStatsRepository
+                    .findAll()
+                    .forEach(
+                            cs -> {
+                                System.out.printf(
+                                        "popupId: %d, itemId: %d, date: %s%n",
+                                        cs.getPopupId(), cs.getItemId(), cs.getAnalyzedDate());
+                            });
+            ConversionItemsResponse response = conversionStatsService.findConversionItems(popupId);
+
+            // then
+            assertThat(response.low()).hasSize(6);
+            assertThat(response.high()).hasSize(6);
+            assertThat(response.low())
+                    .isSortedAccordingTo(Comparator.comparingInt(ConversionItem::conversionRatio));
+            assertThat(response.high())
+                    .isSortedAccordingTo(
+                            Comparator.comparingInt(ConversionItem::conversionRatio).reversed());
+        }
+
+        @Test
+        void 데이터가_존재하지_않으면_빈_리스트를_반환한다() {
+            // given
+            conversionStatsRepository.deleteAll();
+
+            // when
+            ConversionItemsResponse response = conversionStatsService.findConversionItems(1L);
+
+            // then
+            assertThat(response.low()).isEmpty();
+            assertThat(response.high()).isEmpty();
+        }
+    }
+
+    private Popup createTestPopup(Manager manager, String name) {
+        return Popup.createPopup(
+                manager,
+                name,
+                "https://bucket/이미지.jpg",
+                LocalDate.now().minusMonths(1),
+                LocalDate.parse("2025-05-01"),
+                LocalDateTime.of(LocalDate.now().minusMonths(1), LocalTime.of(6, 0)),
+                LocalDateTime.parse("2025-05-01T22:00:00"),
+                LocalTime.parse("06:00:00"),
+                LocalTime.parse("22:00:00"),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456);
+    }
+}

--- a/src/test/java/com/lgcns/domain/entrance/kafka/MemberEnteredConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/entrance/kafka/MemberEnteredConsumerTest.java
@@ -28,7 +28,10 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 @Order(0)
-@EmbeddedKafka(partitions = 1, topics = "member-entered-topic")
+@EmbeddedKafka(
+        partitions = 1,
+        brokerProperties = {"listeners=PLAINTEXT://localhost:9093", "port=9093"},
+        topics = "member-entered-topic")
 public class MemberEnteredConsumerTest extends IntegrationTest {
 
     @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
@@ -60,7 +63,7 @@ public class MemberEnteredConsumerTest extends IntegrationTest {
 
         // then
         Awaitility.await()
-                .atMost(Duration.ofSeconds(5))
+                .atMost(Duration.ofSeconds(15))
                 .untilAsserted(
                         () -> {
                             List<Entrance> entrances = entranceRepository.findAll();

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -32,7 +32,10 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 @Order(0)
-@EmbeddedKafka(partitions = 1, topics = "item-purchased-topic")
+@EmbeddedKafka(
+        partitions = 1,
+        brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"},
+        topics = "item-purchased-topic")
 class ItemPurchasedConsumerTest extends IntegrationTest {
 
     @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
@@ -96,7 +99,7 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
         kafkaTemplate.send("item-purchased-topic", message);
 
         // then
-        await().atMost(Duration.ofSeconds(30))
+        await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(
                         () -> {
                             assertThat(itemRepository.findById(1L).orElseThrow().getStock())

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -96,7 +96,7 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
         kafkaTemplate.send("item-purchased-topic", message);
 
         // then
-        await().atMost(Duration.ofSeconds(15))
+        await().atMost(Duration.ofSeconds(30))
                 .untilAsserted(
                         () -> {
                             assertThat(itemRepository.findById(1L).orElseThrow().getStock())

--- a/src/test/java/com/lgcns/domain/survey/kafka/MemberAnswerConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/survey/kafka/MemberAnswerConsumerTest.java
@@ -36,7 +36,10 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 @Order(0)
-@EmbeddedKafka(partitions = 1, topics = MemberAnswerConsumerTest.TOPIC)
+@EmbeddedKafka(
+        partitions = 1,
+        brokerProperties = {"listeners=PLAINTEXT://localhost:9094", "port=9094"},
+        topics = MemberAnswerConsumerTest.TOPIC)
 public class MemberAnswerConsumerTest extends IntegrationTest {
 
     @Autowired private EmbeddedKafkaBroker embeddedKafkaBroker;
@@ -107,7 +110,7 @@ public class MemberAnswerConsumerTest extends IntegrationTest {
         kafkaTemplate.send(TOPIC, new MemberAnswerMessage(1L, message));
 
         // then
-        await().atMost(Duration.ofSeconds(20))
+        await().atMost(Duration.ofSeconds(15))
                 .untilAsserted(
                         () -> {
                             List<MemberAnswer> memberAnswers = memberAnswerRepository.findAll();


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-142]

---
## 📌 작업 내용 및 특이사항

- 결제 서비스 Internal API를 호출해 팝업별 상품의 관심자 수와 구매자 수를 조회하고, 구매 전환율을 계산하여 저장하도록 구현했습니다.
- 해당 로직은 매 시간마다 실행되는 스케줄러에서 전체 팝업을 대상으로 수행되며, 실시간 조회 대신 DB에 데이터를 저장해두는 방식으로 설계했습니다.
- 구매 전환율(관심자수 / 구매자수 * 100)을 기준으로 하위 6개 / 상위 6개 항목을 조회합니다.
- 모든 팝업에 대해 상품별 구매 전환율을 계산하고, 벌크 insert로 저장 쿼리를 최적화했습니다.
- 호출 시점 기준의 전환율 데이터를 conversion_stats 테이블에 새로 삽입하며, 이력 보존이 목적이기 때문에 update가 아닌 insert로 처리했습니다.
- 관리자가 조회할 때마다 결제 서비스와 DynamoDB를 통해 데이터를 직접 조회하는 구조는 부하가 크기 때문에, 미리 저장된 값을 활용할 수 있도록 개선했습니다.
- 단일 시간대 기준의 집계 데이터만 필요하므로 BaseTimeEntity의 createdAt, updatedAt 필드는 제거했습니다.

## ✅ Kafka Consumer 통합테스트 이슈
- Kafka Consumer 테스트에서 앞선 테스트가 Awaitility 대기 시간을 모두 소진해 다음 테스트에 영향을 주는 문제가 있어, EmbeddedKafka 포트를 테스트마다 다르게 설정해 대기 시간 간섭을 방지했습니다.
또한, 간헐적인 테스트 실패를 방지하고 안정성을 확보하기 위해 Awaitility 대기 시간을 15초로 조정했습니다.

---
## 📚 참고사항

- 구매 전환율 데이터는 매 시간마다 갱신되어 insert되기 때문에, Flyway로 삽입한 목데이터는 초기 테스트용 외에는 의미가 없어 제거가 나아 보입니다.


[LCR-142]: https://lgcns-retail.atlassian.net/browse/LCR-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ