### PR TITLE
refactor: 운영 중인 팝업에 대해서만 통계 저장하도록 개선

### DIFF
--- a/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceImpl.java
@@ -51,7 +51,7 @@ public class ConversionStatsServiceImpl implements ConversionStatsService {
 
     @Override
     public void createConversionStats() {
-        List<Long> popupIds = popupRepository.findAllPopupIds();
+        List<Long> popupIds = popupRepository.findOperatingPopupIds();
 
         List<ConversionStats> statsList = new ArrayList<>();
 

--- a/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceImpl.java
@@ -43,7 +43,7 @@ public class PaymentStatsServiceImpl implements PaymentStatsService {
 
     @Override
     public void createPaymentStats() {
-        List<Long> popupIds = popupRepository.findAllPopupIds();
+        List<Long> popupIds = popupRepository.findOperatingPopupIds();
 
         List<PaymentStats> statsList = new ArrayList<>();
 

--- a/src/main/java/com/lgcns/domain/popup/repository/PopupRepository.java
+++ b/src/main/java/com/lgcns/domain/popup/repository/PopupRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PopupRepository extends JpaRepository<Popup, Long>, PopupRepositoryCustom {
-    @Query("select p.id from Popup p")
-    List<Long> findAllPopupIds();
+    @Query(
+            "select p.id from Popup p where current_date between p.popupStartDate and p.popupEndDate")
+    List<Long> findOperatingPopupIds();
 }

--- a/src/test/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/conversionStats/service/ConversionStatsServiceTest.java
@@ -57,7 +57,13 @@ class ConversionStatsServiceTest extends IntegrationTest {
 
             setAuthentication(manager);
 
-            Popup popup = popupRepository.save(createTestPopup(manager, "popup1"));
+            Popup popup =
+                    popupRepository.save(
+                            createTestPopup(
+                                    manager,
+                                    "popup1",
+                                    LocalDate.of(2025, 6, 1),
+                                    LocalDate.of(2025, 7, 1)));
 
             List<Item> items = new ArrayList<>();
             for (int i = 1; i <= 24; i++) {
@@ -136,8 +142,16 @@ class ConversionStatsServiceTest extends IntegrationTest {
             manager = managerRepository.save(Manager.createManager("testManager", "testPassword"));
             popupRepository.saveAll(
                     List.of(
-                            createTestPopup(manager, "popup1"),
-                            createTestPopup(manager, "popup2")));
+                            createTestPopup(
+                                    manager,
+                                    "popup1",
+                                    LocalDate.of(2025, 6, 1),
+                                    LocalDate.of(2025, 7, 1)),
+                            createTestPopup(
+                                    manager,
+                                    "popup2",
+                                    LocalDate.of(2025, 5, 1),
+                                    LocalDate.of(2025, 6, 1))));
 
             for (long i = 1; i <= 3; i++) {
                 itemRepository.save(
@@ -165,7 +179,7 @@ class ConversionStatsServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 정상적으로_통계_데이터를_저장한다() throws JsonProcessingException {
+        void 운영_중인_팝업만_통계_데이터가_저장된다() throws JsonProcessingException {
             // given
             when(dynamoDbInterestedUserCounter.countInterestedUsers(anyLong(), anyLong()))
                     .thenReturn(150L);
@@ -206,7 +220,7 @@ class ConversionStatsServiceTest extends IntegrationTest {
             // then
             List<ConversionStats> stats = conversionStatsRepository.findAll();
 
-            assertThat(stats).hasSize(6);
+            assertThat(stats).hasSize(3);
 
             assertThat(stats)
                     .extracting(
@@ -214,22 +228,18 @@ class ConversionStatsServiceTest extends IntegrationTest {
                             ConversionStats::getItemId,
                             ConversionStats::getBuyerCount)
                     .containsExactlyInAnyOrder(
-                            tuple(1L, 1L, 100),
-                            tuple(1L, 2L, 80),
-                            tuple(1L, 3L, 60),
-                            tuple(2L, 4L, 40),
-                            tuple(2L, 5L, 20),
-                            tuple(2L, 6L, 10));
+                            tuple(1L, 1L, 100), tuple(1L, 2L, 80), tuple(1L, 3L, 60));
         }
     }
 
-    private Popup createTestPopup(Manager manager, String name) {
+    private Popup createTestPopup(
+            Manager manager, String name, LocalDate popupStartDate, LocalDate popupEndDate) {
         return Popup.createPopup(
                 manager,
                 name,
                 "https://bucket/이미지.jpg",
-                LocalDate.now().minusMonths(1),
-                LocalDate.parse("2025-05-01"),
+                popupStartDate,
+                popupEndDate,
                 LocalDateTime.of(LocalDate.now().minusMonths(1), LocalTime.of(6, 0)),
                 LocalDateTime.parse("2025-05-01T22:00:00"),
                 LocalTime.parse("06:00:00"),

--- a/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/paymentStats/service/PaymentStatsServiceTest.java
@@ -51,7 +51,9 @@ class PaymentStatsServiceTest extends IntegrationTest {
 
             setAuthentication(manager);
 
-            popupRepository.save(createTestPopup(manager, "popup1"));
+            popupRepository.save(
+                    createTestPopup(
+                            manager, "popup1", LocalDate.of(2025, 6, 1), LocalDate.of(2025, 7, 1)));
             paymentStatsRepository.saveAll(
                     List.of(
                             createTestPaymentStats(50000, AveragePeriod.TOTAL),
@@ -95,7 +97,12 @@ class PaymentStatsServiceTest extends IntegrationTest {
         @Test
         void 다른_매니저의_팝업에_접근하면_예외가_발생한다() {
             // given
-            popupRepository.save(createTestPopup(otherManager, "popup2"));
+            popupRepository.save(
+                    createTestPopup(
+                            otherManager,
+                            "popup2",
+                            LocalDate.of(2025, 6, 1),
+                            LocalDate.of(2025, 7, 1)));
 
             // when & then
             assertThatThrownBy(() -> paymentStatsService.findLatestAverageAmount(2L))
@@ -112,12 +119,20 @@ class PaymentStatsServiceTest extends IntegrationTest {
             manager = managerRepository.save(Manager.createManager("testManager1", "testPassword"));
             popupRepository.saveAll(
                     List.of(
-                            createTestPopup(manager, "popup1"),
-                            createTestPopup(manager, "popup2")));
+                            createTestPopup(
+                                    manager,
+                                    "popup1",
+                                    LocalDate.of(2025, 6, 1),
+                                    LocalDate.of(2025, 7, 1)),
+                            createTestPopup(
+                                    manager,
+                                    "popup2",
+                                    LocalDate.of(2025, 5, 1),
+                                    LocalDate.of(2025, 6, 1))));
         }
 
         @Test
-        void 정상적으로_통계_데이터를_저장한다() throws JsonProcessingException {
+        void 운영_중인_팝업만_통계_데이터가_저장된다() throws JsonProcessingException {
             // given
             String expectedResponse1 =
                     objectMapper.writeValueAsString(
@@ -149,7 +164,7 @@ class PaymentStatsServiceTest extends IntegrationTest {
             // then
             List<PaymentStats> stats = paymentStatsRepository.findAll();
 
-            assertThat(stats).hasSize(4);
+            assertThat(stats).hasSize(2);
             assertThat(stats)
                     .extracting(
                             PaymentStats::getPopupId,
@@ -157,19 +172,18 @@ class PaymentStatsServiceTest extends IntegrationTest {
                             PaymentStats::getPeriod)
                     .containsExactlyInAnyOrder(
                             tuple(1L, 300_000, AveragePeriod.TOTAL),
-                            tuple(1L, 100_000, AveragePeriod.TODAY),
-                            tuple(2L, 200_000, AveragePeriod.TOTAL),
-                            tuple(2L, 150_000, AveragePeriod.TODAY));
+                            tuple(1L, 100_000, AveragePeriod.TODAY));
         }
     }
 
-    private Popup createTestPopup(Manager manager, String name) {
+    private Popup createTestPopup(
+            Manager manager, String name, LocalDate popupStartDate, LocalDate popupEndDate) {
         return Popup.createPopup(
                 manager,
                 name,
                 "https://bucket/이미지.jpg",
-                LocalDate.now().minusMonths(1),
-                LocalDate.parse("2025-05-01"),
+                popupStartDate,
+                popupEndDate,
                 LocalDateTime.of(LocalDate.now().minusMonths(1), LocalTime.of(6, 0)),
                 LocalDateTime.parse("2025-05-01T22:00:00"),
                 LocalTime.parse("06:00:00"),


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-308]

---
## 📌 작업 내용 및 특이사항

- 운영 중인 팝업만을 대상으로 통계를 저장하도록 구매 전환율 및 평균 구매액 저장 로직을 개선했습니다.
- 해당 변경 사항을 반영하여 테스트 코드도 수정하였고, 종료된 팝업은 통계 저장 대상에서 제외되는지를 검증하는 테스트를 추가했습니다.


[LCR-308]: https://lgcns-retail.atlassian.net/browse/LCR-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ