### PR TITLE
feat: 상품 재고 부족 시 WebSocket 실시간 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,9 @@ dependencies {
     // Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     testImplementation 'org.springframework.batch:spring-batch-test'
+
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,9 @@ dependencies {
 
     // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // WebSocket Security
+    implementation 'org.springframework.security:spring-security-messaging'
 }
 
 dependencyManagement {

--- a/src/main/java/com/lgcns/domain/item/kafka/consumer/ItemPurchasedConsumer.java
+++ b/src/main/java/com/lgcns/domain/item/kafka/consumer/ItemPurchasedConsumer.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.item.kafka.consumer;
 
 import com.lgcns.domain.item.kafka.message.ItemPurchasedMessage;
 import com.lgcns.domain.item.repository.ItemRepository;
+import com.lgcns.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ public class ItemPurchasedConsumer {
     private static final String TOPIC = "item-purchased-topic";
 
     private final ItemRepository itemRepository;
+    private final NotificationService notificationService;
 
     @KafkaListener(
             topics = TOPIC,
@@ -21,11 +23,16 @@ public class ItemPurchasedConsumer {
     public void decreaseStock(ItemPurchasedMessage message) {
         for (ItemPurchasedMessage.Item item : message.items()) {
             itemRepository
-                    .findById(item.itemId())
+                    .findWithPopupAndManagerById(item.itemId())
                     .ifPresent(
                             foundItem -> {
                                 foundItem.decreaseStock(item.quantity());
                                 itemRepository.save(foundItem);
+
+                                if (foundItem.getStock() <= foundItem.getMinStock()) {
+                                    notificationService.sendLowStockMessage(
+                                            foundItem.getPopup(), foundItem);
+                                }
                             });
         }
     }

--- a/src/main/java/com/lgcns/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/lgcns/domain/item/repository/ItemRepository.java
@@ -1,6 +1,12 @@
 package com.lgcns.domain.item.repository;
 
 import com.lgcns.domain.item.domain.Item;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {}
+public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
+    @Query("select i from Item i join fetch i.popup p join fetch p.manager where i.id = :id")
+    Optional<Item> findWithPopupAndManagerById(@Param("id") Long id);
+}

--- a/src/main/java/com/lgcns/domain/notification/domain/Popularity.java
+++ b/src/main/java/com/lgcns/domain/notification/domain/Popularity.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Popularity {
-    normal("일반 상품"),
-    hot("인기 상품"),
+    NORMAL("일반 상품"),
+    HOT("인기 상품"),
     ;
 
     private final String description;

--- a/src/main/java/com/lgcns/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/lgcns/domain/notification/service/NotificationService.java
@@ -1,9 +1,13 @@
 package com.lgcns.domain.notification.service;
 
+import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.notification.dto.response.NotificationResponse;
+import com.lgcns.domain.popup.domain.Popup;
 import java.util.List;
 
 public interface NotificationService {
 
     List<NotificationResponse> findNotificationList(Long popupId);
+
+    void sendLowStockMessage(Popup popup, Item item);
 }

--- a/src/main/java/com/lgcns/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/notification/service/NotificationServiceImpl.java
@@ -1,9 +1,13 @@
 package com.lgcns.domain.notification.service;
 
+import static com.lgcns.domain.notification.domain.Popularity.HOT;
+import static com.lgcns.domain.notification.domain.Popularity.NORMAL;
+
 import com.lgcns.domain.item.domain.Item;
+import com.lgcns.domain.itemAnalysis.domain.ItemAnalysis;
+import com.lgcns.domain.itemAnalysis.repository.ItemAnalysisRepository;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.notification.domain.Notification;
-import com.lgcns.domain.notification.domain.Popularity;
 import com.lgcns.domain.notification.dto.response.NotificationResponse;
 import com.lgcns.domain.notification.repository.NotificationRepository;
 import com.lgcns.domain.popup.domain.Popup;
@@ -24,9 +28,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class NotificationServiceImpl implements NotificationService {
 
-    private final NotificationRepository notificationRepository;
-    private final PopupRepository popupRepository;
     private final ManagerUtil managerUtil;
+    private final PopupRepository popupRepository;
+    private final NotificationRepository notificationRepository;
+    private final ItemAnalysisRepository itemAnalysisRepository;
 
     private final SimpMessagingTemplate messagingTemplate;
 
@@ -45,13 +50,19 @@ public class NotificationServiceImpl implements NotificationService {
         final Long managerId = popup.getManager().getId();
         final Long popupId = popup.getId();
 
+        List<ItemAnalysis> top3Items = itemAnalysisRepository.findTop3ItemsByPopupId(popupId);
+
+        boolean isHot =
+                top3Items.stream()
+                        .anyMatch(analysis -> analysis.getItem().getId().equals(item.getId()));
+
         Notification notification =
                 Notification.createNotification(
                         managerId,
                         popupId,
                         item.getId(),
                         item.getName(),
-                        Popularity.NORMAL,
+                        isHot ? HOT : NORMAL,
                         item.getMinStock());
 
         notificationRepository.save(notification);

--- a/src/main/java/com/lgcns/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/notification/service/NotificationServiceImpl.java
@@ -1,6 +1,9 @@
 package com.lgcns.domain.notification.service;
 
+import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.notification.domain.Notification;
+import com.lgcns.domain.notification.domain.Popularity;
 import com.lgcns.domain.notification.dto.response.NotificationResponse;
 import com.lgcns.domain.notification.repository.NotificationRepository;
 import com.lgcns.domain.popup.domain.Popup;
@@ -10,9 +13,12 @@ import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -22,6 +28,8 @@ public class NotificationServiceImpl implements NotificationService {
     private final PopupRepository popupRepository;
     private final ManagerUtil managerUtil;
 
+    private final SimpMessagingTemplate messagingTemplate;
+
     @Override
     @Transactional(readOnly = true)
     public List<NotificationResponse> findNotificationList(Long popupId) {
@@ -30,6 +38,33 @@ public class NotificationServiceImpl implements NotificationService {
         validatePopupOwnership(currentManager, popup);
 
         return notificationRepository.findByManagerIdAndPopupId(currentManager.getId(), popupId);
+    }
+
+    @Override
+    public void sendLowStockMessage(Popup popup, Item item) {
+        final Long managerId = popup.getManager().getId();
+        final Long popupId = popup.getId();
+
+        Notification notification =
+                Notification.createNotification(
+                        managerId,
+                        popupId,
+                        item.getId(),
+                        item.getName(),
+                        Popularity.NORMAL,
+                        item.getMinStock());
+
+        notificationRepository.save(notification);
+
+        NotificationResponse response =
+                NotificationResponse.of(
+                        notification.getId(),
+                        notification.getPopularity(),
+                        notification.getItemName(),
+                        notification.getMinStock(),
+                        notification.getCreatedAt());
+
+        messagingTemplate.convertAndSend("/topic/" + managerId + "/popup/" + popupId, response);
     }
 
     private Popup findPopupById(Long popupId) {

--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -66,6 +66,8 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/internal/**")
                                 .permitAll()
+                                .requestMatchers("/ws/**")
+                                .permitAll()
                                 .anyRequest()
                                 .authenticated());
 

--- a/src/main/java/com/lgcns/global/config/security/WebSocketSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSocketSecurityConfig.java
@@ -1,0 +1,24 @@
+package com.lgcns.global.config.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
+import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
+
+@Configuration
+public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBrokerConfigurer {
+
+    @Override
+    protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
+        messages.nullDestMatcher()
+                .permitAll()
+                .simpSubscribeDestMatchers("/topic/**")
+                .authenticated()
+                .anyMessage()
+                .denyAll();
+    }
+
+    @Override
+    protected boolean sameOriginDisabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/lgcns/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/lgcns/global/config/websocket/WebSocketConfig.java
@@ -5,8 +5,10 @@ import static com.lgcns.global.common.constants.UrlConstants.LOCAL_CLIENT_URL;
 import static com.lgcns.global.helper.SpringEnvironmentHelper.DEV;
 
 import com.lgcns.global.helper.SpringEnvironmentHelper;
+import com.lgcns.global.websocket.JwtChannelInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -18,6 +20,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final SpringEnvironmentHelper springEnvironmentHelper;
+    private final JwtChannelInterceptor jwtChannelInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -34,5 +37,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
     }
 }

--- a/src/main/java/com/lgcns/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/lgcns/global/config/websocket/WebSocketConfig.java
@@ -1,0 +1,38 @@
+package com.lgcns.global.config.websocket;
+
+import static com.lgcns.global.common.constants.UrlConstants.DEV_CLIENT_URL;
+import static com.lgcns.global.common.constants.UrlConstants.LOCAL_CLIENT_URL;
+import static com.lgcns.global.helper.SpringEnvironmentHelper.DEV;
+
+import com.lgcns.global.helper.SpringEnvironmentHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final SpringEnvironmentHelper springEnvironmentHelper;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        var endpoint = registry.addEndpoint("/ws");
+
+        switch (springEnvironmentHelper.getCurrentProfile()) {
+            case DEV -> endpoint.setAllowedOriginPatterns(DEV_CLIENT_URL, LOCAL_CLIENT_URL);
+            default -> endpoint.setAllowedOriginPatterns(LOCAL_CLIENT_URL);
+        }
+
+        endpoint.withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+    }
+}

--- a/src/main/java/com/lgcns/global/websocket/JwtChannelInterceptor.java
+++ b/src/main/java/com/lgcns/global/websocket/JwtChannelInterceptor.java
@@ -1,0 +1,73 @@
+package com.lgcns.global.websocket;
+
+import static com.lgcns.global.common.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.lgcns.domain.auth.dto.AccessTokenDto;
+import com.lgcns.domain.auth.service.JwtTokenService;
+import com.lgcns.domain.manager.domain.ManagerRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (!StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(accessor);
+
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+
+            if (accessTokenDto != null) {
+                setAuthenticationToken(accessTokenDto.managerId(), accessTokenDto.role(), accessor);
+            }
+        }
+
+        return message;
+    }
+
+    private void setAuthenticationToken(
+            Long managerId, ManagerRole managerRole, StompHeaderAccessor accessor) {
+        UserDetails userDetails =
+                User.withUsername(managerId.toString())
+                        .password("")
+                        .authorities(managerRole.toString())
+                        .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+        accessor.setUser(authentication);
+    }
+
+    private String extractAccessTokenFromHeader(StompHeaderAccessor accessor) {
+        String header = accessor.getFirstNativeHeader("Authorization");
+
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.replace(TOKEN_PREFIX, "");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/lgcns/global/websocket/WebSocketEventHandler.java
+++ b/src/main/java/com/lgcns/global/websocket/WebSocketEventHandler.java
@@ -1,0 +1,60 @@
+package com.lgcns.global.websocket;
+
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.*;
+
+@Slf4j
+@Component
+public class WebSocketEventHandler {
+
+    @EventListener
+    public void handleWebSocketSessionConnect(SessionConnectEvent event) {
+        logConnectEvent(event);
+    }
+
+    private void logConnectEvent(SessionConnectEvent event) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(event.getMessage(), StompHeaderAccessor.class);
+
+        Authentication authentication = (Authentication) Objects.requireNonNull(accessor.getUser());
+        String username = authentication.getName();
+        String userRole =
+                authentication.getAuthorities().stream()
+                        .findFirst()
+                        .map(GrantedAuthority::getAuthority)
+                        .orElseThrow(() -> new IllegalArgumentException("User role is not exist."));
+
+        log.info(
+                "WebSocket {}: username={}, userRole={}",
+                event.getClass().getSimpleName(),
+                username,
+                userRole);
+    }
+
+    @EventListener(SessionConnectedEvent.class)
+    public void handleWebSocketSessionConnected() {
+        log.info("WebSocket Connected");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionDisconnected(SessionDisconnectEvent event) {
+        log.info("WebSocket Disconnected");
+    }
+
+    @EventListener(SessionSubscribeEvent.class)
+    public void handleWebSocketSessionSubscribe() {
+        log.info("WebSocket Subscribe");
+    }
+
+    @EventListener(SessionUnsubscribeEvent.class)
+    public void handleWebSocketSessionUnsubscribe() {
+        log.info("WebSocket Unsubscribe");
+    }
+}

--- a/src/test/java/com/lgcns/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/lgcns/domain/notification/service/NotificationServiceTest.java
@@ -93,7 +93,7 @@ public class NotificationServiceTest extends IntegrationTest {
             Notification notification =
                     notificationRepository.save(
                             Notification.createNotification(
-                                    managerId, popupId, itemId, "testItem", Popularity.hot, 100));
+                                    managerId, popupId, itemId, "testItem", Popularity.HOT, 100));
 
             // when
             List<NotificationResponse> notificationList =


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-307]

---
## 📌 작업 내용 및 특이사항

- Kafka로 수신한 `ItemPurchasedMessage` 처리 시, 각 상품의 재고를 차감한 뒤 재고가 최소 재고 이하인 경우 알림을 전송하는 로직을 추가했습니다.
- 알림 전송을 위해 WebSocket 설정을 새로 구성하고, 메시지는 `/topic/{managerId}/popup/{popupId}` 경로를 통해 전송됩니다.
- 매니저는 WebSocket 연결은 한 번만 수행한 뒤, 본인이 운영하는 팝업별로 알림을 구독할 수 있습니다.
- 알림 메시지는 `Notification` 엔티티로 저장되며, 전송 시 `NotificationResponse` 형태로 변환됩니다.
- WebSocket 연결 시 JWT 인증을 수행할 수 있도록 `JwtChannelInterceptor`를 구현하였고, `/topic/**` 구독 시 인증이 필요하도록 Spring Security 설정을 추가했습니다.
- WebSocket 연결/구독/해제 이벤트를 서버 로그로 남기기 위한 `WebSocketEventHandler`도 함께 구현했습니다.
- Kafka 리스너 내에서 JPA 엔티티의 연관 필드(popup.manager)에 접근할 때 트랜잭션 경계가 없거나 영속성 컨텍스트가 열려 있지 않아 Lazy 로딩 시 LazyInitializationException이 발생할 수 있습니다.
- 이를 방지하기 위해 ItemRepository의 조회 쿼리를 popup 및 manager를 fetch join하는 방식으로 변경하여, 필요한 연관 데이터를 Kafka 리스너 진입 시점에 한 번에 로딩하도록 최적화했습니다
- 현재 알림 생성 시 상품의 인기도는 기본값으로 NORMAL로 설정하고 있으며 향후 인기 상품 조회 로직이 머지되면 해당 정보를 기반으로 실제 인기도를 반영할 예정입니다.

---
## 📚 참고사항

- 인증 토큰은 STOMP `CONNECT` 프레임의 `Authorization` 헤더로 전달됩니다.
- 클라이언트는 아래와 같이 팝업별 토픽을 구독하면 알림을 받을 수 있습니다:
  ```js
  stompClient.subscribe("/topic/1/popup/1", callback); // managerId: 1, popupId: 3
  ```
- 테스트 결과 다음과 같습니다.
![image](https://github.com/user-attachments/assets/82a3dc61-3bf7-4482-b243-1d15a2714339)


[LCR-307]: https://lgcns-retail.atlassian.net/browse/LCR-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ