### PR TITLE
feat: 혼잡도 분석 스케쥴링 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobManager.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobManager.java
@@ -1,0 +1,84 @@
+package com.lgcns.domain.congestionStats.batch;
+
+import com.lgcns.domain.congestionStats.domain.CongestionStats;
+import com.lgcns.domain.visitorStats.domain.VisitorStats;
+import com.lgcns.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class CongestionStatsJobManager {
+
+    public static final Integer CHUNK_SIZE = 100;
+    public static final Integer TASK_POOL_SIZE = 2;
+    public static final String CONGESTION_STATS_JOB = "congestionStatsJob";
+    public static final String CREATE_CONGESTION_STATS_STEP = "createCongestionStatsStep";
+    public static final String CONGESTION_STATS_TASK_EXECUTOR = "congestionStatsTaskExecutor";
+
+    private static final String CREATE_CONGESTION_STATS_ITEM_READER =
+            "createCongestionStatsItemReader";
+    private static final String CREATE_CONGESTION_STATS_ITEM_PROCESSOR =
+            "createCongestionStatsItemProcessor";
+    private static final String CREATE_CONGESTION_STATS_ITEM_WRITER =
+            "createCongestionStatsItemWriter";
+
+    @Bean(name = CONGESTION_STATS_JOB)
+    public Job congestionStatsJob(JobRepository jobRepository, Step createCongestionStatsStep) {
+        return new JobBuilder(CONGESTION_STATS_JOB, jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(createCongestionStatsStep)
+                .build();
+    }
+
+    @Bean(name = CREATE_CONGESTION_STATS_STEP)
+    @JobScope
+    public Step createCongestionStatsStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            @Qualifier(CREATE_CONGESTION_STATS_ITEM_READER)
+                    ItemReader<Long> createCongestionStatsItemReader,
+            @Qualifier(CREATE_CONGESTION_STATS_ITEM_PROCESSOR)
+                    ItemProcessor<Long, CongestionStats> createCongestonStatsItemProcessor,
+            @Qualifier(CREATE_CONGESTION_STATS_ITEM_WRITER)
+                    ItemWriter<CongestionStats> createCongestionStatsItemWriter,
+            @Qualifier(CONGESTION_STATS_TASK_EXECUTOR) TaskExecutor taskExecutor) {
+        return new StepBuilder(CREATE_CONGESTION_STATS_STEP, jobRepository)
+                .<Long, VisitorStats>chunk(CHUNK_SIZE, transactionManager)
+                .reader(createCongestionStatsItemReader)
+                .processor(createCongestonStatsItemProcessor)
+                .writer(createCongestionStatsItemWriter)
+                .faultTolerant()
+                .retryLimit(3)
+                .retry(DataAccessException.class)
+                .skipLimit(3)
+                .skip(CustomException.class)
+                .taskExecutor(taskExecutor)
+                .build();
+    }
+
+    @Bean(name = CONGESTION_STATS_TASK_EXECUTOR)
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(TASK_POOL_SIZE);
+        taskExecutor.setMaxPoolSize(TASK_POOL_SIZE * 2);
+        taskExecutor.setThreadNamePrefix("async-thread");
+        return taskExecutor;
+    }
+}

--- a/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobManager.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobManager.java
@@ -1,7 +1,6 @@
 package com.lgcns.domain.congestionStats.batch;
 
 import com.lgcns.domain.congestionStats.domain.CongestionStats;
-import com.lgcns.domain.visitorStats.domain.VisitorStats;
 import com.lgcns.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -32,13 +31,6 @@ public class CongestionStatsJobManager {
     public static final String CREATE_CONGESTION_STATS_STEP = "createCongestionStatsStep";
     public static final String CONGESTION_STATS_TASK_EXECUTOR = "congestionStatsTaskExecutor";
 
-    private static final String CREATE_CONGESTION_STATS_ITEM_READER =
-            "createCongestionStatsItemReader";
-    private static final String CREATE_CONGESTION_STATS_ITEM_PROCESSOR =
-            "createCongestionStatsItemProcessor";
-    private static final String CREATE_CONGESTION_STATS_ITEM_WRITER =
-            "createCongestionStatsItemWriter";
-
     @Bean(name = CONGESTION_STATS_JOB)
     public Job congestionStatsJob(JobRepository jobRepository, Step createCongestionStatsStep) {
         return new JobBuilder(CONGESTION_STATS_JOB, jobRepository)
@@ -52,15 +44,15 @@ public class CongestionStatsJobManager {
     public Step createCongestionStatsStep(
             JobRepository jobRepository,
             PlatformTransactionManager transactionManager,
-            @Qualifier(CREATE_CONGESTION_STATS_ITEM_READER)
+            @Qualifier(CongestionStatsStepManager.CREATE_CONGESTION_STATS_ITEM_READER)
                     ItemReader<Long> createCongestionStatsItemReader,
-            @Qualifier(CREATE_CONGESTION_STATS_ITEM_PROCESSOR)
+            @Qualifier(CongestionStatsStepManager.CREATE_CONGESTION_STATS_ITEM_PROCESSOR)
                     ItemProcessor<Long, CongestionStats> createCongestonStatsItemProcessor,
-            @Qualifier(CREATE_CONGESTION_STATS_ITEM_WRITER)
+            @Qualifier(CongestionStatsStepManager.CREATE_CONGESTION_STATS_ITEM_WRITER)
                     ItemWriter<CongestionStats> createCongestionStatsItemWriter,
             @Qualifier(CONGESTION_STATS_TASK_EXECUTOR) TaskExecutor taskExecutor) {
         return new StepBuilder(CREATE_CONGESTION_STATS_STEP, jobRepository)
-                .<Long, VisitorStats>chunk(CHUNK_SIZE, transactionManager)
+                .<Long, CongestionStats>chunk(CHUNK_SIZE, transactionManager)
                 .reader(createCongestionStatsItemReader)
                 .processor(createCongestonStatsItemProcessor)
                 .writer(createCongestionStatsItemWriter)

--- a/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsScheduler.java
@@ -1,3 +1,45 @@
 package com.lgcns.domain.congestionStats.batch;
 
-public class CongestionStatsScheduler {}
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CongestionStatsScheduler {
+
+    public static final String CONGESTION_STATS_JOB = "congestionStatsJob";
+
+    private final Job congestionStatsJob;
+    private final JobLauncher jobLauncher;
+
+    public CongestionStatsScheduler(
+            @Qualifier(CONGESTION_STATS_JOB) Job congestionStatsJob, JobLauncher jobLauncher) {
+        this.congestionStatsJob = congestionStatsJob;
+        this.jobLauncher = jobLauncher;
+    }
+
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    public void createCongestionStats()
+            throws JobInstanceAlreadyCompleteException,
+                    JobExecutionAlreadyRunningException,
+                    JobParametersInvalidException,
+                    JobRestartException {
+
+        String dateHour = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+
+        JobParameters jobParameters =
+                new JobParametersBuilder().addString("dateHour", dateHour).toJobParameters();
+
+        jobLauncher.run(congestionStatsJob, jobParameters);
+    }
+}

--- a/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsScheduler.java
@@ -1,0 +1,3 @@
+package com.lgcns.domain.congestionStats.batch;
+
+public class CongestionStatsScheduler {}

--- a/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsStepManager.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsStepManager.java
@@ -18,11 +18,12 @@ import org.springframework.context.annotation.Configuration;
 public class CongestionStatsStepManager {
 
     private final CongestionStatsService congestionStatsService;
-    private static final String CREATE_CONGESTION_STATS_ITEM_READER =
+
+    public static final String CREATE_CONGESTION_STATS_ITEM_READER =
             "createCongestionStatsItemReader";
-    private static final String CREATE_CONGESTION_STATS_ITEM_PROCESSOR =
+    public static final String CREATE_CONGESTION_STATS_ITEM_PROCESSOR =
             "createCongestionStatsItemProcessor";
-    private static final String CREATE_CONGESTION_STATS_ITEM_WRITER =
+    public static final String CREATE_CONGESTION_STATS_ITEM_WRITER =
             "createCongestionStatsItemWriter";
 
     @Bean(name = CREATE_CONGESTION_STATS_ITEM_READER)

--- a/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsStepManager.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/batch/CongestionStatsStepManager.java
@@ -1,0 +1,56 @@
+package com.lgcns.domain.congestionStats.batch;
+
+import com.lgcns.domain.congestionStats.domain.CongestionStats;
+import com.lgcns.domain.congestionStats.service.CongestionStatsService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class CongestionStatsStepManager {
+
+    private final CongestionStatsService congestionStatsService;
+    private static final String CREATE_CONGESTION_STATS_ITEM_READER =
+            "createCongestionStatsItemReader";
+    private static final String CREATE_CONGESTION_STATS_ITEM_PROCESSOR =
+            "createCongestionStatsItemProcessor";
+    private static final String CREATE_CONGESTION_STATS_ITEM_WRITER =
+            "createCongestionStatsItemWriter";
+
+    @Bean(name = CREATE_CONGESTION_STATS_ITEM_READER)
+    @StepScope
+    public ItemReader<Long> createCongestionStatsItemReader() {
+        ListItemReader<Long> delegate =
+                new ListItemReader<>(congestionStatsService.findTargetPopupIds());
+
+        return new ItemReader<>() {
+            @Override
+            public synchronized Long read() {
+                return delegate.read();
+            }
+        };
+    }
+
+    @Bean(name = CREATE_CONGESTION_STATS_ITEM_PROCESSOR)
+    @StepScope
+    public ItemProcessor<Long, CongestionStats> createCongestionStatsItemProcessor() {
+        return congestionStatsService::convertCongestionStats;
+    }
+
+    @Bean(name = CREATE_CONGESTION_STATS_ITEM_WRITER)
+    @StepScope
+    public ItemWriter<CongestionStats> createCongestionStatsItemWriter() {
+        return chunk -> {
+            List<CongestionStats> congestionStatsList = new ArrayList<>(chunk.getItems());
+            congestionStatsService.createCongestionStats(congestionStatsList);
+        };
+    }
+}

--- a/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryCustom.java
@@ -1,10 +1,15 @@
 package com.lgcns.domain.congestionStats.repository;
 
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public interface CongestionStatsRepositoryCustom {
 
     CongestionStatsResponse findDailyCongestionStats(
             Long popupId, LocalTime startTime, LocalTime endTime);
+
+    List<Long> findPopupIdsWithoutCongestionStats(
+            List<Long> popupIds, LocalDate nowDate, LocalTime nowTime);
 }

--- a/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.congestionStats.repository;
 
+import com.lgcns.domain.congestionStats.domain.CongestionStats;
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -12,4 +13,6 @@ public interface CongestionStatsRepositoryCustom {
 
     List<Long> findPopupIdsWithoutCongestionStats(
             List<Long> popupIds, LocalDate nowDate, LocalTime nowTime);
+
+    void bulkInsertCongestionStats(List<CongestionStats> congestionStatsList);
 }

--- a/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Function;
@@ -94,6 +95,25 @@ public class CongestionStatsRepositoryImpl implements CongestionStatsRepositoryC
                 responseMap.get(DayOfWeek.FRIDAY),
                 responseMap.get(DayOfWeek.SATURDAY),
                 responseMap.get(DayOfWeek.SUNDAY));
+    }
+
+    @Override
+    public List<Long> findPopupIdsWithoutCongestionStats(
+            List<Long> popupIds, LocalDate nowDate, LocalTime nowTime) {
+        List<Long> existingIds =
+                queryFactory
+                        .select(congestionStats.popupId)
+                        .distinct()
+                        .from(congestionStats)
+                        .where(
+                                congestionStats.popupId.in(popupIds),
+                                congestionStats.analyzedDate.eq(nowDate),
+                                congestionStats.analyzedTime.hour().eq(nowTime.getHour()))
+                        .fetch();
+
+        return popupIds.stream()
+                .filter(id -> !existingIds.contains(id))
+                .collect(Collectors.toList());
     }
 
     private List<Integer> generateHourlyTimeList(LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryImpl.java
@@ -7,7 +7,9 @@ import com.lgcns.domain.congestionStats.dto.response.DailyCongestionStatsRespons
 import com.lgcns.domain.reservationStats.dto.response.DayOfWeek;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -48,18 +50,22 @@ public class CongestionStatsRepositoryImpl implements CongestionStatsRepositoryC
                         .then(6)
                         .otherwise(7);
 
+        NumberTemplate<Integer> groupedHour =
+                Expressions.numberTemplate(
+                        Integer.class, "FLOOR(HOUR({0}) / 2) * 2", congestionStats.analyzedTime);
+
         List<DailyCongestionStatsResponse> result =
                 queryFactory
                         .select(
                                 Projections.constructor(
                                         DailyCongestionStatsResponse.class,
                                         congestionStats.dayOfWeek,
-                                        congestionStats.analyzedTime.hour(),
+                                        groupedHour,
                                         congestionStats.entrantCount.avg().intValue()))
                         .from(congestionStats)
                         .where(congestionStats.popupId.eq(popupId))
-                        .groupBy(congestionStats.dayOfWeek, congestionStats.analyzedTime)
-                        .orderBy(dayOfWeekOrder.asc(), congestionStats.analyzedTime.asc())
+                        .groupBy(congestionStats.dayOfWeek, groupedHour)
+                        .orderBy(dayOfWeekOrder.asc(), groupedHour.asc())
                         .fetch();
 
         Map<DayOfWeek, Map<Integer, DailyCongestionStatsResponse>> statsMap =

--- a/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/repository/CongestionStatsRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.congestionStats.repository;
 
 import static com.lgcns.domain.congestionStats.domain.QCongestionStats.congestionStats;
 
+import com.lgcns.domain.congestionStats.domain.CongestionStats;
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
 import com.lgcns.domain.congestionStats.dto.response.DailyCongestionStatsResponse;
 import com.lgcns.domain.reservationStats.dto.response.DayOfWeek;
@@ -11,6 +12,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
@@ -18,12 +20,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
 public class CongestionStatsRepositoryImpl implements CongestionStatsRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
     @Override
     public CongestionStatsResponse findDailyCongestionStats(
@@ -120,6 +124,42 @@ public class CongestionStatsRepositoryImpl implements CongestionStatsRepositoryC
         return popupIds.stream()
                 .filter(id -> !existingIds.contains(id))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void bulkInsertCongestionStats(List<CongestionStats> statsList) {
+        if (statsList.isEmpty()) return;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("INSERT INTO congestion_stats ")
+                .append(
+                        "(popup_id, entrant_count, day_of_week, analyzed_date, analyzed_time) VALUES ");
+
+        for (int i = 0; i < statsList.size(); i++) {
+            CongestionStats s = statsList.get(i);
+
+            sb.append("(")
+                    .append(s.getPopupId())
+                    .append(", ")
+                    .append(s.getEntrantCount())
+                    .append(", ")
+                    .append("'")
+                    .append(s.getDayOfWeek().name())
+                    .append("', ")
+                    .append("'")
+                    .append(s.getAnalyzedDate())
+                    .append("', ")
+                    .append("'")
+                    .append(s.getAnalyzedTime())
+                    .append("')");
+
+            if (i < statsList.size() - 1) {
+                sb.append(", ");
+            }
+        }
+
+        em.createNativeQuery(sb.toString()).executeUpdate();
     }
 
     private List<Integer> generateHourlyTimeList(LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsService.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsService.java
@@ -11,4 +11,6 @@ public interface CongestionStatsService {
     List<Long> findTargetPopupIds();
 
     CongestionStats convertCongestionStats(Long popupId);
+
+    void createCongestionStats(List<CongestionStats> congestionStatsList);
 }

--- a/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsService.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsService.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.congestionStats.service;
 
+import com.lgcns.domain.congestionStats.domain.CongestionStats;
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface CongestionStatsService {
     CongestionStatsResponse getCongestionStats(Long popupId);
 
     List<Long> findTargetPopupIds();
+
+    CongestionStats convertCongestionStats(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsService.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsService.java
@@ -1,8 +1,11 @@
 package com.lgcns.domain.congestionStats.service;
 
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
+import java.util.List;
 
 public interface CongestionStatsService {
 
     CongestionStatsResponse getCongestionStats(Long popupId);
+
+    List<Long> findTargetPopupIds();
 }

--- a/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceImpl.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.congestionStats.service;
 
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
 import com.lgcns.domain.congestionStats.repository.CongestionStatsRepository;
+import com.lgcns.domain.entrance.repository.EntranceRepository;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
@@ -9,6 +10,10 @@ import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +24,7 @@ public class CongestionStatsServiceImpl implements CongestionStatsService {
 
     private final CongestionStatsRepository congestionStatsRepository;
     private final PopupRepository popupRepository;
+    private final EntranceRepository entranceRepository;
     private final ManagerUtil managerUtil;
 
     @Override
@@ -31,6 +37,21 @@ public class CongestionStatsServiceImpl implements CongestionStatsService {
 
         return congestionStatsRepository.findDailyCongestionStats(
                 popupId, popup.getRunOpenTime(), popup.getRunCloseTime());
+    }
+
+    @Override
+    public List<Long> findTargetPopupIds() {
+        LocalDate nowDate = LocalDate.now();
+        LocalTime nowTime = LocalTime.now();
+
+        // 운영 중인 팝업 필터링
+        List<Long> popupIds = popupRepository.findAllPopupIdsAfterPopupStartTime(nowDate, nowTime);
+        // 입장 내역이 존재하는 팝업 필터링
+        List<Long> popupIdsWithEntrances = entranceRepository.findPopupIdsWithEntrances(popupIds);
+        // 중복된 혼잡도 분석이 존재하지 않는 팝업 필터링
+        return new ArrayList<>(
+                congestionStatsRepository.findPopupIdsWithoutCongestionStats(
+                        popupIdsWithEntrances, nowDate, nowTime));
     }
 
     private void validatePopupOwnership(Manager manager, Popup popup) {

--- a/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceImpl.java
@@ -72,6 +72,11 @@ public class CongestionStatsServiceImpl implements CongestionStatsService {
                 nowTime);
     }
 
+    @Override
+    public void createCongestionStats(List<CongestionStats> congestionStatsList) {
+        congestionStatsRepository.bulkInsertCongestionStats(congestionStatsList);
+    }
+
     private void validatePopupOwnership(Manager manager, Popup popup) {
         if (!popup.getManager().equals(manager)) {
             throw new CustomException(PopupErrorCode.POPUP_UNAUTHORIZED);

--- a/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.congestionStats.service;
 
+import com.lgcns.domain.congestionStats.domain.CongestionStats;
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
 import com.lgcns.domain.congestionStats.repository.CongestionStatsRepository;
 import com.lgcns.domain.entrance.repository.EntranceRepository;
@@ -7,6 +8,7 @@ import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
+import com.lgcns.domain.reservationStats.dto.response.DayOfWeek;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import jakarta.transaction.Transactional;
@@ -52,6 +54,22 @@ public class CongestionStatsServiceImpl implements CongestionStatsService {
         return new ArrayList<>(
                 congestionStatsRepository.findPopupIdsWithoutCongestionStats(
                         popupIdsWithEntrances, nowDate, nowTime));
+    }
+
+    @Override
+    public CongestionStats convertCongestionStats(Long popupId) {
+        LocalDate nowDate = LocalDate.now();
+        LocalTime nowTime = LocalTime.now();
+        java.time.DayOfWeek dayOfWeek = nowDate.getDayOfWeek();
+
+        Long hourlyCount = entranceRepository.findHourlyEntranceCount(popupId, nowDate, nowTime);
+
+        return CongestionStats.createCongestionStats(
+                popupId,
+                hourlyCount.intValue(),
+                DayOfWeek.valueOf(dayOfWeek.name()),
+                nowDate,
+                nowTime);
     }
 
     private void validatePopupOwnership(Manager manager, Popup popup) {

--- a/src/main/java/com/lgcns/domain/entrance/repository/EntranceRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/entrance/repository/EntranceRepositoryCustom.java
@@ -14,4 +14,6 @@ public interface EntranceRepositoryCustom {
             Long popupId, LocalDate nowDate, LocalTime nowTime);
 
     List<Long> findPopupIdsWithEntrances(List<Long> popupIds);
+
+    Long findHourlyEntranceCount(Long popupId, LocalDate nowDate, LocalTime nowTime);
 }

--- a/src/main/java/com/lgcns/domain/entrance/repository/EntranceRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/entrance/repository/EntranceRepositoryImpl.java
@@ -76,6 +76,18 @@ public class EntranceRepositoryImpl implements EntranceRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public Long findHourlyEntranceCount(Long popupId, LocalDate nowDate, LocalTime nowTime) {
+        return queryFactory
+                .select(entrance.count())
+                .from(entrance)
+                .where(
+                        entrance.popupId.eq(popupId),
+                        entrance.reservationDate.eq(nowDate),
+                        entrance.reservationTime.eq(getPreviousHour(nowTime)))
+                .fetchOne();
+    }
+
     private NumberExpression<Integer> createGenderCountCase(MemberGender gender) {
         return new CaseBuilder().when(entrance.gender.eq(gender)).then(1).otherwise(0).sum();
     }

--- a/src/test/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobTest.java
+++ b/src/test/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobTest.java
@@ -1,3 +1,238 @@
 package com.lgcns.domain.congestionStats.batch;
 
-public class CongestionStatsJobTest {}
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.lgcns.IntegrationTest;
+import com.lgcns.domain.entrance.domain.Entrance;
+import com.lgcns.domain.entrance.domain.MemberAge;
+import com.lgcns.domain.entrance.domain.MemberGender;
+import com.lgcns.domain.entrance.repository.EntranceRepository;
+import com.lgcns.domain.manager.domain.Manager;
+import com.lgcns.domain.manager.repository.ManagerRepository;
+import com.lgcns.domain.popup.domain.Popup;
+import com.lgcns.domain.popup.repository.PopupRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.*;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@SpringBatchTest
+public class CongestionStatsJobTest extends IntegrationTest {
+
+    public static final String CONGESTION_STATS_JOB = "congestionStatsJob";
+
+    @Autowired private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired private PopupRepository popupRepository;
+
+    @Autowired private ManagerRepository managerRepository;
+
+    @Autowired private EntranceRepository entranceRepository;
+
+    private Manager ownerManager;
+
+    @Autowired
+    @Qualifier(CONGESTION_STATS_JOB)
+    Job congestionStatsJob;
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils.setJob(congestionStatsJob);
+
+        ownerManager =
+                managerRepository.save(Manager.createManager("ownerManager", "ownerPassword"));
+
+        setAuthentication(ownerManager);
+    }
+
+    @Nested
+    class congestion_stats_job이_실행될_때 {
+
+        @Test
+        void 진행_중인_팝업이_없어도_실행에_성공한다() throws Exception {
+            // given
+            Popup popup = createClosedPopup();
+            popupRepository.save(popup);
+
+            JobParameters jobParameters = buildJobParameters();
+
+            // when
+            JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+            StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+            // then
+            assertAll(
+                    () -> assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED),
+                    () -> assertThat(stepExecution.getReadCount()).isEqualTo(0),
+                    () -> assertThat(stepExecution.getWriteCount()).isEqualTo(0),
+                    () -> assertThat(stepExecution.getSkipCount()).isEqualTo(0));
+        }
+
+        @Test
+        void 진행_중인_팝업에_입장_정보가_없어도_실행에_성공한다() throws Exception {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+
+            JobParameters jobParameters = buildJobParameters();
+
+            // when
+            JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+            StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+            // then
+            assertAll(
+                    () -> assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED),
+                    () -> assertThat(stepExecution.getReadCount()).isEqualTo(0),
+                    () -> assertThat(stepExecution.getWriteCount()).isEqualTo(0),
+                    () -> assertThat(stepExecution.getSkipCount()).isEqualTo(0));
+        }
+
+        @Test
+        void 진행_중인_팝업에_한_시간_전_입장_정보가_없어도_실행에_성공한다() throws Exception {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            LocalDate nowDate = LocalDate.now();
+            LocalTime nowTime = LocalTime.now();
+
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(2)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(2)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(2)));
+
+            JobParameters jobParameters = buildJobParameters();
+
+            // when
+            JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+            StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+            // then
+            assertAll(
+                    () -> assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED),
+                    () -> assertThat(stepExecution.getReadCount()).isEqualTo(1),
+                    () -> assertThat(stepExecution.getWriteCount()).isEqualTo(1),
+                    () -> assertThat(stepExecution.getSkipCount()).isEqualTo(0));
+        }
+
+        @Test
+        void 진행_중인_팝업에_한_시간_전_입장_정보가_있으면_실행에_성공한다() throws Exception {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            LocalDate nowDate = LocalDate.now();
+            LocalTime nowTime = LocalTime.now();
+
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+
+            JobParameters jobParameters = buildJobParameters();
+
+            // when
+            JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+            StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+            // then
+            assertAll(
+                    () -> assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED),
+                    () -> assertThat(stepExecution.getReadCount()).isEqualTo(1),
+                    () -> assertThat(stepExecution.getWriteCount()).isEqualTo(1),
+                    () -> assertThat(stepExecution.getSkipCount()).isEqualTo(0));
+        }
+    }
+
+    private JobParameters buildJobParameters() {
+        return new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+    }
+
+    private Popup createClosedPopup() {
+        return Popup.createPopup(
+                ownerManager,
+                "testPopup",
+                "https://bucket/이미지.jpg",
+                LocalDate.parse("2020-01-01"),
+                LocalDate.parse("2020-01-31"),
+                LocalDateTime.parse("2025-01-01T10:00:00"),
+                LocalDateTime.parse("2025-01-31T20:00:00"),
+                LocalTime.parse("10:00:00"),
+                LocalTime.parse("20:00:00"),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456);
+    }
+
+    private Popup createRunningPopup() {
+        LocalDate nowDate = LocalDate.now();
+
+        return Popup.createPopup(
+                ownerManager,
+                "testPopup",
+                "https://bucket/이미지.jpg",
+                nowDate,
+                nowDate.plusMonths(5),
+                LocalDateTime.parse("2025-01-01T10:00:00"),
+                LocalDateTime.parse("2025-01-31T20:00:00"),
+                LocalTime.parse("00:00:00"),
+                LocalTime.parse("23:59:59"),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456);
+    }
+}

--- a/src/test/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobTest.java
+++ b/src/test/java/com/lgcns/domain/congestionStats/batch/CongestionStatsJobTest.java
@@ -1,0 +1,3 @@
+package com.lgcns.domain.congestionStats.batch;
+
+public class CongestionStatsJobTest {}

--- a/src/test/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceTest.java
@@ -9,6 +9,10 @@ import com.lgcns.domain.congestionStats.domain.CongestionStats;
 import com.lgcns.domain.congestionStats.dto.response.CongestionStatsResponse;
 import com.lgcns.domain.congestionStats.dto.response.DailyCongestionStatsResponse;
 import com.lgcns.domain.congestionStats.repository.CongestionStatsRepository;
+import com.lgcns.domain.entrance.domain.Entrance;
+import com.lgcns.domain.entrance.domain.MemberAge;
+import com.lgcns.domain.entrance.domain.MemberGender;
+import com.lgcns.domain.entrance.repository.EntranceRepository;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.popup.domain.Popup;
@@ -20,6 +24,8 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +39,7 @@ public class CongestionStatsServiceTest extends IntegrationTest {
 
     @Autowired ManagerRepository managerRepository;
     @Autowired PopupRepository popupRepository;
+    @Autowired EntranceRepository entranceRepository;
 
     private Manager ownerManager;
     private Manager otherManager;
@@ -139,6 +146,196 @@ public class CongestionStatsServiceTest extends IntegrationTest {
         }
     }
 
+    @Nested
+    class 진행_중인_팝업_id_리스트를_조회할_때 {
+
+        @Test
+        void 운영_중이고_입장_내역이_존재하며_중복된_혼잡도_분석이_없는_팝업이_존재하면_조회에_성공한다() {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            LocalDate.now(),
+                            LocalTime.parse("10:00:00")));
+
+            // when
+            List<Long> result = congestionStatsService.findTargetPopupIds();
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result).hasSize(1),
+                    () -> assertThat(result.get(0)).isEqualTo(popupId));
+        }
+
+        @Test
+        void 운영_중인_팝업이_없으면_빈_리스트가_조회된다() {
+            // given
+            Popup popup = createClosedPopup();
+            popupRepository.save(popup);
+
+            // when
+            List<Long> result = congestionStatsService.findTargetPopupIds();
+
+            // then
+            assertAll(() -> assertThat(result).isNotNull(), () -> assertThat(result).hasSize(0));
+        }
+
+        @Test
+        void 운영_중인_팝업에_대해_입장_내역이_없으면_조회에_포함되지_않는다() {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+
+            // when
+            List<Long> result = congestionStatsService.findTargetPopupIds();
+
+            // then
+            assertAll(() -> assertThat(result).isNotNull(), () -> assertThat(result).hasSize(0));
+        }
+
+        @Test
+        void 운영_중인_팝업에_대해_중복된_혼잡도_분석이_존재하면_조회에_포함되지_않는다() {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            LocalDate.now(),
+                            LocalTime.parse("10:00:00")));
+
+            LocalDate nowDate = LocalDate.now();
+            LocalTime nowTime = LocalTime.now();
+
+            congestionStatsRepository.save(
+                    CongestionStats.createCongestionStats(
+                            popupId, 1, DayOfWeek.MONDAY, nowDate, nowTime));
+
+            // when
+            List<Long> result = congestionStatsService.findTargetPopupIds();
+
+            // then
+            assertAll(() -> assertThat(result).isNotNull(), () -> assertThat(result).hasSize(0));
+        }
+    }
+
+    @Nested
+    class 혼잡도_분석을_생성할_때 {
+
+        @Test
+        void 한_시간_전_입장_내역이_존재하면_생성에_성공한다() {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            LocalDate nowDate = LocalDate.now();
+            LocalTime nowTime = LocalTime.now();
+
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TEENAGER,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.FEMALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.THIRTIES,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.FEMALE,
+                            MemberAge.FORTIES_AND_ABOVE,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+            entranceRepository.save(
+                    Entrance.createPopupEnter(
+                            popupId,
+                            MemberGender.MALE,
+                            MemberAge.TWENTIES,
+                            nowDate,
+                            nowTime.minusHours(1).truncatedTo(ChronoUnit.HOURS)));
+
+            // when
+            CongestionStats result = congestionStatsService.convertCongestionStats(popupId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.getPopupId()).isEqualTo(popupId),
+                    () -> assertThat(result.getEntrantCount()).isEqualTo(5),
+                    () ->
+                            assertThat(result.getDayOfWeek())
+                                    .isEqualTo(DayOfWeek.valueOf(nowDate.getDayOfWeek().name())),
+                    () -> assertThat(result.getAnalyzedDate()).isEqualTo(nowDate),
+                    () ->
+                            assertThat(result.getAnalyzedTime().truncatedTo(ChronoUnit.SECONDS))
+                                    .isEqualTo(nowTime.truncatedTo(ChronoUnit.SECONDS)));
+        }
+    }
+
+    @Nested
+    class 혼잡도_분석_리스트를_저장할_때 {
+
+        @Test
+        void 혼잡도_분석_리스트가_존재하면_저장에_성공한다() {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            List<CongestionStats> congestionStatsList = createCongestionStatsList(popupId);
+
+            // when
+            congestionStatsService.createCongestionStats(congestionStatsList);
+
+            // then
+            List<CongestionStats> result = congestionStatsRepository.findAll();
+
+            assertAll(
+                    () -> assertThat(result).isNotEmpty(),
+                    () -> assertThat(result).hasSize(3),
+                    () ->
+                            assertThat(result.get(0).getPopupId())
+                                    .isEqualTo(congestionStatsList.get(0).getPopupId()),
+                    () ->
+                            assertThat(result.get(0).getEntrantCount())
+                                    .isEqualTo(congestionStatsList.get(0).getEntrantCount()),
+                    () ->
+                            assertThat(result.get(0).getDayOfWeek())
+                                    .isEqualTo(congestionStatsList.get(0).getDayOfWeek()),
+                    () ->
+                            assertThat(result.get(0).getAnalyzedDate())
+                                    .isEqualTo(congestionStatsList.get(0).getAnalyzedDate()),
+                    () ->
+                            assertThat(result.get(0).getAnalyzedTime())
+                                    .isEqualTo(congestionStatsList.get(0).getAnalyzedTime()));
+        }
+    }
+
     private void createCongestionStats(Popup popup) {
         Long popupId = popup.getId();
         LocalDate startDate = LocalDate.of(2025, 5, 17);
@@ -162,5 +359,82 @@ public class CongestionStatsServiceTest extends IntegrationTest {
                 congestionStatsRepository.save(stats);
             }
         }
+    }
+
+    private Popup createClosedPopup() {
+        return Popup.createPopup(
+                ownerManager,
+                "testPopup",
+                "https://bucket/이미지.jpg",
+                LocalDate.parse("2020-01-01"),
+                LocalDate.parse("2020-01-31"),
+                LocalDateTime.parse("2025-01-01T10:00:00"),
+                LocalDateTime.parse("2025-01-31T20:00:00"),
+                LocalTime.parse("10:00:00"),
+                LocalTime.parse("20:00:00"),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456);
+    }
+
+    private Popup createRunningPopup() {
+        LocalDate nowDate = LocalDate.now();
+
+        return Popup.createPopup(
+                ownerManager,
+                "testPopup",
+                "https://bucket/이미지.jpg",
+                nowDate,
+                nowDate.plusMonths(5),
+                LocalDateTime.parse("2025-01-01T10:00:00"),
+                LocalDateTime.parse("2025-01-31T20:00:00"),
+                LocalTime.parse("00:00:00"),
+                LocalTime.parse("23:59:59"),
+                100,
+                20,
+                "서울특별시 강남구 테헤란로 123",
+                "3층 A호",
+                37.123456,
+                127.123456);
+    }
+
+    private List<CongestionStats> createCongestionStatsList(Long popupId) {
+        List<CongestionStats> congestionStatsList = new ArrayList<>();
+
+        LocalDate date = LocalDate.of(2025, 6, 10);
+        java.time.DayOfWeek dayOfWeek = date.getDayOfWeek();
+
+        CongestionStats stats1 =
+                CongestionStats.createCongestionStats(
+                        popupId,
+                        20,
+                        DayOfWeek.valueOf(dayOfWeek.name()),
+                        date,
+                        LocalTime.of(10, 0));
+
+        CongestionStats stats2 =
+                CongestionStats.createCongestionStats(
+                        popupId,
+                        35,
+                        DayOfWeek.valueOf(dayOfWeek.name()),
+                        date,
+                        LocalTime.of(11, 0));
+
+        CongestionStats stats3 =
+                CongestionStats.createCongestionStats(
+                        popupId,
+                        42,
+                        DayOfWeek.valueOf(dayOfWeek.name()),
+                        date,
+                        LocalTime.of(12, 0));
+
+        congestionStatsList.add(stats1);
+        congestionStatsList.add(stats2);
+        congestionStatsList.add(stats3);
+
+        return congestionStatsList;
     }
 }

--- a/src/test/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/congestionStats/service/CongestionStatsServiceTest.java
@@ -295,6 +295,33 @@ public class CongestionStatsServiceTest extends IntegrationTest {
                             assertThat(result.getAnalyzedTime().truncatedTo(ChronoUnit.SECONDS))
                                     .isEqualTo(nowTime.truncatedTo(ChronoUnit.SECONDS)));
         }
+
+        @Test
+        void 한_시간_전_입장_내역이_없으면_입장자_카운트에_0이_저장된다() {
+            // given
+            Popup popup = createRunningPopup();
+            popupRepository.save(popup);
+            Long popupId = popup.getId();
+
+            LocalDate nowDate = LocalDate.now();
+            LocalTime nowTime = LocalTime.now();
+
+            // when
+            CongestionStats result = congestionStatsService.convertCongestionStats(popupId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).isNotNull(),
+                    () -> assertThat(result.getPopupId()).isEqualTo(popupId),
+                    () -> assertThat(result.getEntrantCount()).isEqualTo(0),
+                    () ->
+                            assertThat(result.getDayOfWeek())
+                                    .isEqualTo(DayOfWeek.valueOf(nowDate.getDayOfWeek().name())),
+                    () -> assertThat(result.getAnalyzedDate()).isEqualTo(nowDate),
+                    () ->
+                            assertThat(result.getAnalyzedTime().truncatedTo(ChronoUnit.SECONDS))
+                                    .isEqualTo(nowTime.truncatedTo(ChronoUnit.SECONDS)));
+        }
     }
 
     @Nested

--- a/src/test/java/com/lgcns/domain/entrance/kafka/MemberEnteredConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/entrance/kafka/MemberEnteredConsumerTest.java
@@ -63,7 +63,7 @@ public class MemberEnteredConsumerTest extends IntegrationTest {
 
         // then
         Awaitility.await()
-                .atMost(Duration.ofSeconds(15))
+                .atMost(Duration.ofSeconds(25))
                 .untilAsserted(
                         () -> {
                             List<Entrance> entrances = entranceRepository.findAll();

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -99,7 +99,7 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
         kafkaTemplate.send("item-purchased-topic", message);
 
         // then
-        await().atMost(Duration.ofSeconds(15))
+        await().atMost(Duration.ofSeconds(25))
                 .untilAsserted(
                         () -> {
                             assertThat(itemRepository.findById(1L).orElseThrow().getStock())

--- a/src/test/java/com/lgcns/domain/survey/kafka/MemberAnswerConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/survey/kafka/MemberAnswerConsumerTest.java
@@ -110,7 +110,7 @@ public class MemberAnswerConsumerTest extends IntegrationTest {
         kafkaTemplate.send(TOPIC, new MemberAnswerMessage(1L, message));
 
         // then
-        await().atMost(Duration.ofSeconds(20))
+        await().atMost(Duration.ofSeconds(25))
                 .untilAsserted(
                         () -> {
                             List<MemberAnswer> memberAnswers = memberAnswerRepository.findAll();


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-265]

---
## 📌 작업 내용 및 특이사항

- 혼잡도 분석 생성 기능 스케쥴링을 구현했습니다.
</br>

- 혼잡도 분석 스케쥴러는 한 시간 단위로 동작하며 방문자 분석 생성 Job을 실행합니다.
- 혼잡도 분석 Job 및 방문자 분석 생성 Step을 구성하고, 실제 서비스 로직은 혼잡도 분석 서비스단에서 구현했습니다.
  - 혼잡도 분석 생성 Step은 '진행 중인 팝업 리스트 조회(Reader) -> 혼잡도 분석 생성(Processor) -> DB에 저장(Writer) 순서로 동작합니다.
  - 혼잡도 분석 생성 Step은 Reader 단계에서 조회된 데이터를 100개 단위로 나눠 Processor, Writer 단계를 수행합니다.
  - Writer 단계에서 DataAccessException이 발생하면 Step은 재실행되고, 3번 이상 재실행되면 Step은 스킵됩니다.
  - Processor, Writer 성능 개선을 위해 TaskExecutor을 구현하여 Step이 멀티 스레드 환경에서 실행되도록 구성했습니다.
  - Reader 단계는 thread-safe 환경에서 실행되도록 synchronized 설정을 추가했습니다.
</br>

- 혼잡도 분석 생성 Insert 성능을 개선하고자 Native Query를 사용하여 Bulk Insert를 구현했습니다.
- Writer 단계에서 받은 혼잡도 분석 리스트를 한 번의 Insert 쿼리로 DB에 저장합니다.
</br>

- Batch 테스트에 @SpringBatchTest를 활성화하고 JobLauncherTestUtils을 사용하여 혼잡도 분석 Job을 등록했습니다.
- 혼잡도 분석 생성 Step에서 사용하는 서비스에 대해 테스트 코드를 작성했습니다.

---
## 📚 참고사항

-


[LCR-265]: https://lgcns-retail.atlassian.net/browse/LCR-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ