### PR TITLE
chore: Prometheus, Grafana, Loki 기반 통합 모니터링 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     // Prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // Grafana Loki
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -1,0 +1,25 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml

--- a/loki/loki-config.yml
+++ b/loki/loki-config.yml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -9,10 +9,12 @@ management:
         exclude: "*"
     web:
       exposure:
-        include: health
+        include: health, prometheus
       base-path: /manager-actuator
     access:
       default: none
   endpoint:
     health:
+      access: unrestricted
+    prometheus:
       access: unrestricted

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProfile name="local">
+        <property name="LOKI_URL" value="http://localhost:3100/loki/api/v1/push"/>
+    </springProfile>
+    <springProfile name="dev">
+        <property name="LOKI_URL" value="http://loki.monitoring.svc:3100/loki/api/v1/push"/>
+    </springProfile>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=popi,service=manager-service,level=%level</pattern>
+            </label>
+            <message class="com.github.loki4j.logback.JsonLayout"/>
+        </format>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LOKI"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework.core " level="error"/>
+    <logger name="org.springframework.beans" level="error"/>
+    <logger name="org.springframework.context" level="error"/>
+    <logger name="org.springframework.transaction" level="error"/>
+    <logger name="org.springframework.web" level="error"/>
+    <logger name="org.springframework.test" level="error"/>
+    <logger name="org.hibernate" level="error"/>
+</configuration>


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-326]

---
## 📌 작업 내용 및 특이사항

- 로컬 모니터링 환경 구성
  - Grafana, Prometheus, Loki로 로그 수집 및 시각화가 가능하도록 docker-compose-monitoring.yml을 구성했습니다.
  - Prometheus(prometheus.yml)와 Loki(loki-config.yml)의 설정 파일은 각각 prometheus/, loki/ 디렉토리 하위에 정리했습니다.
  - 로컬 환경에서는 로그 데이터 수집과 시각화 확인이 목적이므로, Grafana 등의 데이터 디렉토리(grafana-data/)는 제거하고, 불필요한 볼륨 마운트 없이 ephemeral(임시) 구성으로 세팅했습니다.

- 로그 전송 및 환경별 분기
  - logback-spring.xml에서 Loki 로그 전송용 LOKI_URL을 정의하고, springProfile에 따라 로컬(localhost)과 EKS(loki.monitoring.svc)에서 자동 분기되도록 구성했습니다. (EKS에서는 Helm 기준 DNS로 접근)

- Loki 선택 배경
  - 기존 ELK(Elasticsearch-Logstash-Kibana) 스택 대신 Loki를 도입한 이유는 운영 및 인프라 부담이 적으면서, Grafana와의 네이티브 통합이 가능하고, 특히 EKS 환경에서는 Helm Chart로 Prometheus, Grafana, Loki를 일관성 있게 관리할 수 있기 때문입니다.
  - 이를 통해 메트릭과 로그 시각화를 하나의 환경에서 효율적으로 구축하고, 추가적인 리소스/운영 복잡도를 최소화할 수 있습니다.

- 테스트 환경 최적화
  - 테스트 및 CI 환경에서는 logback-test.xml을 별도 관리하여, 콘솔 로그만 출력하고 외부 Loki 전송을 차단했습니다.
  - 또한, Spring, Hibernate 등 불필요하게 많은 로그가 찍히는 주요 패키지의 로그 레벨을 error로 조정하여, 테스트 시 실제 필요한 로그만 깔끔하게 확인할 수 있도록 최적화했습니다.

[LCR-326]: https://lgcns-retail.atlassian.net/browse/LCR-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ