### PR TITLE
feat: 발주 목록 조회 및 업데이트 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/entrance/kafka/config/MemberEnteredConsumerConfig.java
+++ b/src/main/java/com/lgcns/domain/entrance/kafka/config/MemberEnteredConsumerConfig.java
@@ -41,7 +41,7 @@ public class MemberEnteredConsumerConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, MemberEnteredMessage>
-            memberEnteredMessageConcurrentKafkaListenerContainerFactory() {
+            memberEnteredConcurrentKafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, MemberEnteredMessage>
                 kafkaListenerContainerFactory = new ConcurrentKafkaListenerContainerFactory<>();
         kafkaListenerContainerFactory.setConsumerFactory(memberEnteredConsumerFactory());

--- a/src/main/java/com/lgcns/domain/entrance/kafka/config/MemberEnteredConsumerConfig.java
+++ b/src/main/java/com/lgcns/domain/entrance/kafka/config/MemberEnteredConsumerConfig.java
@@ -23,7 +23,7 @@ public class MemberEnteredConsumerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ConsumerFactory<String, MemberEnteredMessage> memberEnteredMessageConsumerFactory() {
+    public ConsumerFactory<String, MemberEnteredMessage> memberEnteredConsumerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -44,7 +44,7 @@ public class MemberEnteredConsumerConfig {
             memberEnteredMessageConcurrentKafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, MemberEnteredMessage>
                 kafkaListenerContainerFactory = new ConcurrentKafkaListenerContainerFactory<>();
-        kafkaListenerContainerFactory.setConsumerFactory(memberEnteredMessageConsumerFactory());
+        kafkaListenerContainerFactory.setConsumerFactory(memberEnteredConsumerFactory());
         return kafkaListenerContainerFactory;
     }
 }

--- a/src/main/java/com/lgcns/domain/entrance/kafka/consumer/MemberEnteredConsumer.java
+++ b/src/main/java/com/lgcns/domain/entrance/kafka/consumer/MemberEnteredConsumer.java
@@ -20,7 +20,7 @@ public class MemberEnteredConsumer {
     @KafkaListener(
             topics = TOPIC,
             groupId = "member-entered",
-            containerFactory = "memberEnteredMessageConcurrentKafkaListenerContainerFactory")
+            containerFactory = "memberEnteredConcurrentKafkaListenerContainerFactory")
     public void createEntrance(MemberEnteredMessage message) {
 
         Entrance entrance =

--- a/src/main/java/com/lgcns/domain/item/domain/Item.java
+++ b/src/main/java/com/lgcns/domain/item/domain/Item.java
@@ -121,4 +121,12 @@ public class Item extends BaseTimeEntity {
     public Boolean checkOutOfStockAndAlarmed() {
         return this.stock <= this.minStock + this.averageSales && !this.isAlarmed;
     }
+
+    public void updateStock(int stock) {
+        if (stock < 0) {
+            throw new CustomException(ItemErrorCode.INVALID_RESTOCK);
+        }
+        this.stock = stock;
+        this.lastRestockDateTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
+++ b/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
@@ -12,7 +12,10 @@ public enum ItemErrorCode implements ErrorCode {
     ITEM_POPUP_MISMATCH(HttpStatus.BAD_REQUEST, "해당 팝업에 등록된 상품이 아닙니다."),
     MIN_STOCK_EXCEEDED(HttpStatus.BAD_REQUEST, "최소 발주 수량은 재고 수량보다 크게 설정할 수 없습니다."),
 
-    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "요청한 수량이 현재 재고보다 많습니다.");
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "요청한 수량이 현재 재고보다 많습니다."),
+    INVALID_RESTOCK(HttpStatus.BAD_REQUEST, "재고 수량은 0 이상이어야 합니다."),
+    ;
+
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/lgcns/domain/orderItem/domian/OrderItem.java
+++ b/src/main/java/com/lgcns/domain/orderItem/domian/OrderItem.java
@@ -1,6 +1,8 @@
 package com.lgcns.domain.orderItem.domian;
 
 import com.lgcns.domain.item.domain.Item;
+import com.lgcns.domain.item.exception.ItemErrorCode;
+import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.model.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -36,5 +38,16 @@ public class OrderItem extends BaseTimeEntity {
 
     public static OrderItem createOrderItem(Item item) {
         return OrderItem.builder().item(item).build();
+    }
+
+    public void updateOrderItem(Integer realCount, OrderItemStatus status) {
+        if (status == OrderItemStatus.COMPLETED && realCount < 0) {
+            throw new CustomException(ItemErrorCode.INVALID_RESTOCK);
+        }
+
+        if (status == OrderItemStatus.COMPLETED) this.realCount = realCount;
+
+        if (status == OrderItemStatus.CANCELED || status == OrderItemStatus.COMPLETED)
+            this.status = status;
     }
 }

--- a/src/main/java/com/lgcns/domain/orderItem/domian/OrderItem.java
+++ b/src/main/java/com/lgcns/domain/orderItem/domian/OrderItem.java
@@ -49,5 +49,6 @@ public class OrderItem extends BaseTimeEntity {
 
         if (status == OrderItemStatus.CANCELED || status == OrderItemStatus.COMPLETED)
             this.status = status;
+        item.updateIsAlarmed(false);
     }
 }

--- a/src/main/java/com/lgcns/domain/orderItem/domian/OrderItemStatus.java
+++ b/src/main/java/com/lgcns/domain/orderItem/domian/OrderItemStatus.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum OrderItemStatus {
     PENDING("PENDING"),
     COMPLETED("COMPLETED"),
-    CANCELLED("CANCELLED");
+    CANCELED("CANCELED");
 
     private final String description;
 }

--- a/src/main/java/com/lgcns/domain/orderItem/dto/request/OrderItemUpdateRequest.java
+++ b/src/main/java/com/lgcns/domain/orderItem/dto/request/OrderItemUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.lgcns.domain.orderItem.dto.request;
+
+import com.lgcns.domain.orderItem.domian.OrderItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record OrderItemUpdateRequest(
+        @Schema(description = "발주 수량", example = "10") Integer qty,
+        @Schema(description = "발주 상태", example = "CANCELED") @NotNull OrderItemStatus status) {}

--- a/src/main/java/com/lgcns/domain/orderItem/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/lgcns/domain/orderItem/dto/response/OrderItemResponse.java
@@ -1,0 +1,12 @@
+package com.lgcns.domain.orderItem.dto.response;
+
+import com.lgcns.domain.orderItem.domian.OrderItemStatus;
+import java.time.LocalDateTime;
+
+public record OrderItemResponse(
+        Long orderItemId,
+        String itemName,
+        Integer recommendCount,
+        Integer realCount,
+        LocalDateTime lastRestockDateTime,
+        OrderItemStatus status) {}

--- a/src/main/java/com/lgcns/domain/orderItem/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/lgcns/domain/orderItem/dto/response/OrderItemResponse.java
@@ -1,12 +1,14 @@
 package com.lgcns.domain.orderItem.dto.response;
 
 import com.lgcns.domain.orderItem.domian.OrderItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record OrderItemResponse(
-        Long orderItemId,
-        String itemName,
-        Integer recommendCount,
-        Integer realCount,
-        LocalDateTime lastRestockDateTime,
-        OrderItemStatus status) {}
+        @Schema(description = "발주 ID", example = "1") Long orderItemId,
+        @Schema(description = "상품명", example = "블랙핑크 키링") String itemName,
+        @Schema(description = "추천 발주 수량", example = "10") Integer recommendCount,
+        @Schema(description = "실제 발주 수량", example = "8") Integer realCount,
+        @Schema(description = "발주 날짜", example = "2023-10-01T10:00:00")
+                LocalDateTime lastRestockDateTime,
+        @Schema(description = "발주 상태", example = "PENDING") OrderItemStatus status) {}

--- a/src/main/java/com/lgcns/domain/orderItem/externalApi/OrderItemController.java
+++ b/src/main/java/com/lgcns/domain/orderItem/externalApi/OrderItemController.java
@@ -1,0 +1,32 @@
+package com.lgcns.domain.orderItem.externalApi;
+
+import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
+import com.lgcns.domain.orderItem.service.OrderItemService;
+import com.lgcns.global.common.response.SliceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/order-items")
+@RequiredArgsConstructor
+@Tag(name = "13. 발주 API", description = "발주 관련 External API 입니다.")
+public class OrderItemController {
+
+    private final OrderItemService orderItemService;
+
+    @GetMapping("/{popupId}")
+    @Operation(summary = "팝업 상품에 대한 발주 조회", description = "주어진 팝업 ID에 대한 발주 내역을 페이징 처리하여 조회합니다.")
+    public SliceResponse<OrderItemResponse> orderItemFindAll(
+            @PathVariable Long popupId,
+            @Parameter(description = "이전 페이지의 마지막 ID (첫 요청 시 비워두세요.)", example = "2")
+                    @RequestParam(required = false)
+                    Long lastOrderItemId,
+            @Parameter(description = "페이지 크기 (기본 8)", example = "8")
+                    @RequestParam(defaultValue = "8")
+                    int size) {
+        return orderItemService.findOrderItemsByPopupId(popupId, lastOrderItemId, size);
+    }
+}

--- a/src/main/java/com/lgcns/domain/orderItem/externalApi/OrderItemController.java
+++ b/src/main/java/com/lgcns/domain/orderItem/externalApi/OrderItemController.java
@@ -1,12 +1,15 @@
 package com.lgcns.domain.orderItem.externalApi;
 
+import com.lgcns.domain.orderItem.dto.request.OrderItemUpdateRequest;
 import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
 import com.lgcns.domain.orderItem.service.OrderItemService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,5 +31,14 @@ public class OrderItemController {
                     @RequestParam(defaultValue = "8")
                     int size) {
         return orderItemService.findOrderItemsByPopupId(popupId, lastOrderItemId, size);
+    }
+
+    @PatchMapping("/status/{orderItemId}")
+    @Operation(summary = "발주 상태 변경", description = "주어진 발주 ID에 대한 발주 상태를 변경합니다.")
+    public ResponseEntity<Void> orderItemUpdate(
+            @PathVariable Long orderItemId,
+            @Valid @RequestBody OrderItemUpdateRequest orderItemUpdateRequest) {
+        orderItemService.updateOrderItem(orderItemId, orderItemUpdateRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepository.java
+++ b/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepository.java
@@ -1,7 +1,13 @@
 package com.lgcns.domain.orderItem.repository;
 
 import com.lgcns.domain.orderItem.domian.OrderItem;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OrderItemRepository
-        extends JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {}
+        extends JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
+
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.item i WHERE oi.id = :orderItemId")
+    Optional<OrderItem> findById(Long orderItemId);
+}

--- a/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepository.java
+++ b/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepository.java
@@ -3,4 +3,5 @@ package com.lgcns.domain.orderItem.repository;
 import com.lgcns.domain.orderItem.domian.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {}
+public interface OrderItemRepository
+        extends JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {}

--- a/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepositoryCustom.java
+++ b/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.lgcns.domain.orderItem.repository;
+
+import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
+import org.springframework.data.domain.Slice;
+
+public interface OrderItemRepositoryCustom {
+    Slice<OrderItemResponse> findOrderItemsByPopupIdWithPagination(
+            Long popupId, Long lastOrderItemId, int size);
+}

--- a/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepositoryImpl.java
+++ b/src/main/java/com/lgcns/domain/orderItem/repository/OrderItemRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.lgcns.domain.orderItem.repository;
+
+import static com.lgcns.domain.item.domain.QItem.item;
+import static com.lgcns.domain.orderItem.domian.QOrderItem.orderItem;
+import static com.lgcns.domain.popup.domain.QPopup.popup;
+
+import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderItemRepositoryImpl implements OrderItemRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Slice<OrderItemResponse> findOrderItemsByPopupIdWithPagination(
+            Long popupId, Long lastOrderItemId, int size) {
+        List<OrderItemResponse> results =
+                jpaQueryFactory
+                        .select(
+                                Projections.constructor(
+                                        OrderItemResponse.class,
+                                        orderItem.id,
+                                        orderItem.item.name,
+                                        orderItem.item.recommendCount,
+                                        orderItem.realCount,
+                                        orderItem.item.lastRestockDateTime,
+                                        orderItem.status))
+                        .from(orderItem)
+                        .join(orderItem.item, item)
+                        .join(item.popup, popup)
+                        .where(popup.id.eq(popupId), lastOrderItemCondition(lastOrderItemId))
+                        .orderBy(orderItem.id.desc())
+                        .limit(size + 1L)
+                        .fetch();
+        return checkLastPage(size, results);
+    }
+
+    private BooleanExpression lastOrderItemCondition(Long lastOrderItemId) {
+        return (lastOrderItemId != null) ? orderItem.id.lt(lastOrderItemId) : null;
+    }
+
+    private <T> Slice<T> checkLastPage(int pageSize, List<T> results) {
+        boolean hasNext = false;
+
+        if (results.size() > pageSize) {
+            hasNext = true;
+            results.remove(pageSize);
+        }
+
+        return new SliceImpl<>(results, PageRequest.of(0, pageSize), hasNext);
+    }
+}

--- a/src/main/java/com/lgcns/domain/orderItem/service/OrderItemService.java
+++ b/src/main/java/com/lgcns/domain/orderItem/service/OrderItemService.java
@@ -1,5 +1,6 @@
 package com.lgcns.domain.orderItem.service;
 
+import com.lgcns.domain.orderItem.dto.request.OrderItemUpdateRequest;
 import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
 import com.lgcns.global.common.response.SliceResponse;
 
@@ -9,4 +10,6 @@ public interface OrderItemService {
 
     SliceResponse<OrderItemResponse> findOrderItemsByPopupId(
             Long popupId, Long lastOrderItemId, int size);
+
+    void updateOrderItem(Long orderItemId, OrderItemUpdateRequest orderItemUpdateRequest);
 }

--- a/src/main/java/com/lgcns/domain/orderItem/service/OrderItemService.java
+++ b/src/main/java/com/lgcns/domain/orderItem/service/OrderItemService.java
@@ -1,6 +1,12 @@
 package com.lgcns.domain.orderItem.service;
 
+import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
+import com.lgcns.global.common.response.SliceResponse;
+
 public interface OrderItemService {
 
     void createOrderItem(Long itemId);
+
+    SliceResponse<OrderItemResponse> findOrderItemsByPopupId(
+            Long popupId, Long lastOrderItemId, int size);
 }

--- a/src/main/java/com/lgcns/domain/orderItem/service/OrderItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/orderItem/service/OrderItemServiceImpl.java
@@ -4,7 +4,9 @@ import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.exception.ItemErrorCode;
 import com.lgcns.domain.item.repository.ItemRepository;
 import com.lgcns.domain.orderItem.domian.OrderItem;
+import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
 import com.lgcns.domain.orderItem.repository.OrderItemRepository;
+import com.lgcns.global.common.response.SliceResponse;
 import com.lgcns.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,5 +30,13 @@ public class OrderItemServiceImpl implements OrderItemService {
         OrderItem orderItem = OrderItem.createOrderItem(item);
         orderItemRepository.save(orderItem);
         item.updateIsAlarmed(true);
+    }
+
+    @Override
+    public SliceResponse<OrderItemResponse> findOrderItemsByPopupId(
+            Long popupId, Long lastOrderItemId, int size) {
+        return SliceResponse.from(
+                orderItemRepository.findOrderItemsByPopupIdWithPagination(
+                        popupId, lastOrderItemId, size));
     }
 }

--- a/src/main/java/com/lgcns/domain/orderItem/service/OrderItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/orderItem/service/OrderItemServiceImpl.java
@@ -4,6 +4,7 @@ import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.exception.ItemErrorCode;
 import com.lgcns.domain.item.repository.ItemRepository;
 import com.lgcns.domain.orderItem.domian.OrderItem;
+import com.lgcns.domain.orderItem.dto.request.OrderItemUpdateRequest;
 import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
 import com.lgcns.domain.orderItem.repository.OrderItemRepository;
 import com.lgcns.global.common.response.SliceResponse;
@@ -38,5 +39,17 @@ public class OrderItemServiceImpl implements OrderItemService {
         return SliceResponse.from(
                 orderItemRepository.findOrderItemsByPopupIdWithPagination(
                         popupId, lastOrderItemId, size));
+    }
+
+    @Override
+    public void updateOrderItem(Long orderItemId, OrderItemUpdateRequest orderItemUpdateRequest) {
+        OrderItem orderItem =
+                orderItemRepository
+                        .findById(orderItemId)
+                        .orElseThrow(() -> new CustomException(ItemErrorCode.ITEM_NOT_FOUND));
+
+        orderItem.updateOrderItem(orderItemUpdateRequest.qty(), orderItemUpdateRequest.status());
+        orderItem.getItem().updateStock(orderItemUpdateRequest.qty());
+        orderItemRepository.save(orderItem);
     }
 }

--- a/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/item/kafka/ItemPurchasedConsumerTest.java
@@ -99,7 +99,7 @@ class ItemPurchasedConsumerTest extends IntegrationTest {
         kafkaTemplate.send("item-purchased-topic", message);
 
         // then
-        await().atMost(Duration.ofSeconds(25))
+        await().atMost(Duration.ofSeconds(30))
                 .untilAsserted(
                         () -> {
                             assertThat(itemRepository.findById(1L).orElseThrow().getStock())

--- a/src/test/java/com/lgcns/domain/orderItem/service/OrderItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/orderItem/service/OrderItemServiceTest.java
@@ -188,6 +188,7 @@ public class OrderItemServiceTest extends IntegrationTest {
             OrderItem updatedOrderItem = orderItemRepository.findById(orderItemId).orElseThrow();
             assertThat(updatedOrderItem.getRealCount()).isEqualTo(10);
             assertThat(updatedOrderItem.getStatus()).isEqualTo(OrderItemStatus.COMPLETED);
+            assertThat(updatedOrderItem.getItem().getIsAlarmed()).isFalse();
         }
 
         @Test

--- a/src/test/java/com/lgcns/domain/orderItem/service/OrderItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/orderItem/service/OrderItemServiceTest.java
@@ -10,13 +10,17 @@ import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.manager.repository.ManagerRepository;
 import com.lgcns.domain.orderItem.domian.OrderItem;
 import com.lgcns.domain.orderItem.domian.OrderItemStatus;
+import com.lgcns.domain.orderItem.dto.request.OrderItemUpdateRequest;
+import com.lgcns.domain.orderItem.dto.response.OrderItemResponse;
 import com.lgcns.domain.orderItem.repository.OrderItemRepository;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.repository.PopupRepository;
+import com.lgcns.global.common.response.SliceResponse;
 import com.lgcns.global.error.exception.CustomException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -100,6 +104,122 @@ public class OrderItemServiceTest extends IntegrationTest {
                     CustomException.class,
                     () -> orderItemService.createOrderItem(nonExistentItemId),
                     ItemErrorCode.ITEM_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    class 발주_목록을_조회할_때 {
+
+        @Test
+        void 팝업_ID로_발주_목록을_조회한다() {
+            // given
+            Long popupId = popup.getId();
+            for (int i = 0; i < 10; i++) {
+                Item testItem =
+                        itemRepository.save(
+                                Item.createItem(
+                                        popup,
+                                        "testItem" + i,
+                                        "https://bucket/이미지" + i + ".jpg",
+                                        1000 + i,
+                                        5 + i,
+                                        10 + i,
+                                        "a2"));
+                OrderItem orderItem = OrderItem.createOrderItem(testItem);
+                orderItemRepository.save(orderItem);
+            }
+
+            // when
+            SliceResponse<OrderItemResponse> result1 =
+                    orderItemService.findOrderItemsByPopupId(popupId, null, 8);
+            List<OrderItemResponse> result1ResponseList = result1.content();
+            Long lastOrderItemId1 =
+                    result1ResponseList.get(result1ResponseList.size() - 1).orderItemId();
+            SliceResponse<OrderItemResponse> result2 =
+                    orderItemService.findOrderItemsByPopupId(popupId, lastOrderItemId1, 8);
+            List<OrderItemResponse> result2ResponseList = result2.content();
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result1).isNotNull(),
+                    () -> org.assertj.core.api.Assertions.assertThat(result1.content()).hasSize(8),
+                    () -> assertThat(result1.isLast()).isFalse(),
+                    () -> {
+                        for (int i = 0; i < result1ResponseList.size(); i++) {
+                            OrderItemResponse response = result1ResponseList.get(i);
+
+                            assertThat(response.itemName()).isEqualTo("testItem" + (9 - i));
+                            assertThat(response.recommendCount()).isEqualTo(5 + (9 - i));
+                            assertThat(response.realCount()).isEqualTo(-1);
+                            assertThat(response.status()).isEqualTo(OrderItemStatus.PENDING);
+                        }
+                    },
+                    () -> assertThat(result2).isNotNull(),
+                    () -> org.assertj.core.api.Assertions.assertThat(result2.content()).hasSize(2),
+                    () -> assertThat(result2.isLast()).isTrue(),
+                    () -> {
+                        for (int i = 0; i < result2ResponseList.size(); i++) {
+                            OrderItemResponse response = result2ResponseList.get(i);
+
+                            assertThat(response.itemName()).isEqualTo("testItem" + (1 - i));
+                            assertThat(response.recommendCount()).isEqualTo(5 + (1 - i));
+                            assertThat(response.realCount()).isEqualTo(-1);
+                            assertThat(response.status()).isEqualTo(OrderItemStatus.PENDING);
+                        }
+                    });
+        }
+    }
+
+    @Nested
+    class 발주_상태를_변경할_때 {
+
+        @Test
+        void 발주_상태를_변경한다() {
+            // given
+            OrderItem orderItem = OrderItem.createOrderItem(item);
+            orderItemRepository.save(orderItem);
+            Long orderItemId = orderItem.getId();
+
+            // when
+            orderItemService.updateOrderItem(
+                    orderItemId, new OrderItemUpdateRequest(10, OrderItemStatus.COMPLETED));
+
+            // then
+            OrderItem updatedOrderItem = orderItemRepository.findById(orderItemId).orElseThrow();
+            assertThat(updatedOrderItem.getRealCount()).isEqualTo(10);
+            assertThat(updatedOrderItem.getStatus()).isEqualTo(OrderItemStatus.COMPLETED);
+        }
+
+        @Test
+        void 존재하지_않는_발주_ID로_상태를_변경하면_예외가_발생한다() {
+            // given
+            Long nonExistentOrderItemId = -999L;
+
+            // when, then
+            Assertions.assertThrows(
+                    CustomException.class,
+                    () ->
+                            orderItemService.updateOrderItem(
+                                    nonExistentOrderItemId,
+                                    new OrderItemUpdateRequest(10, OrderItemStatus.COMPLETED)),
+                    ItemErrorCode.ITEM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 발주_상태가_COMPLETED일_때_실제_발주_수량이_음수이면_예외가_발생한다() {
+            // given
+            OrderItem orderItem = OrderItem.createOrderItem(item);
+            orderItemRepository.save(orderItem);
+            Long orderItemId = orderItem.getId();
+
+            // when, then
+            Assertions.assertThrows(
+                    CustomException.class,
+                    () ->
+                            orderItemService.updateOrderItem(
+                                    orderItemId,
+                                    new OrderItemUpdateRequest(-5, OrderItemStatus.COMPLETED)),
+                    ItemErrorCode.INVALID_RESTOCK.getMessage());
         }
     }
 }

--- a/src/test/java/com/lgcns/domain/survey/kafka/MemberAnswerConsumerTest.java
+++ b/src/test/java/com/lgcns/domain/survey/kafka/MemberAnswerConsumerTest.java
@@ -110,7 +110,7 @@ public class MemberAnswerConsumerTest extends IntegrationTest {
         kafkaTemplate.send(TOPIC, new MemberAnswerMessage(1L, message));
 
         // then
-        await().atMost(Duration.ofSeconds(25))
+        await().atMost(Duration.ofSeconds(30))
                 .untilAsserted(
                         () -> {
                             List<MemberAnswer> memberAnswers = memberAnswerRepository.findAll();


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-338]

---
## 📌 작업 내용 및 특이사항

- 발주 목록 조회 API 구현했습니다.
- 발주 상태 변경 API 구현했습니다. 발주 상태 "COMPLETED" 로 변경할 시 요청한 qty에 맞게 realCount를 설정하고, 재고를 증가시킵니다.

---
![image](https://github.com/user-attachments/assets/e4d67fc7-31ad-4397-90a0-2f070af4db45)


[LCR-338]: https://lgcns-retail.atlassian.net/browse/LCR-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ