### PR TITLE
feat: Internal 인기 상품 리스트 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
@@ -71,6 +71,6 @@ public class ItemController {
             summary = "실시간 인기 상품 조회",
             description = "팝업 오픈부터 직전 타임까지의 관심도와 판매량을 기준으로 상위 3개의 인기 상품을 조회합니다.")
     public List<ItemTrendingResponse> TrendingItemFind(@PathVariable Long popupId) {
-        return itemService.getTrendingItems(popupId);
+        return itemService.getTrendingItemsByManager(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -3,6 +3,7 @@ package com.lgcns.domain.item.internalApi;
 import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
+import com.lgcns.domain.item.dto.response.ItemTrendingResponse;
 import com.lgcns.domain.item.service.ItemService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,9 +63,9 @@ public class ItemInternalController {
 
     @GetMapping("/popularity")
     @Operation(summary = "인기 상품 목록 조회", description = "카메라 점수 및 실구매율 기반 인기 상품 3개를 조회합니다.")
-    public List<ItemInfoResponse> itemFindPopularity(
+    public List<ItemTrendingResponse> itemFindPopularity(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId) {
-        return itemService.findItemsPopularity(popupId);
+        return itemService.getTrendingItems(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -59,4 +59,12 @@ public class ItemInternalController {
             @RequestBody ItemIdsForPaymentRequest request) {
         return itemService.findItemsForPayment(popupId, request);
     }
+
+    @GetMapping("/popularity")
+    @Operation(summary = "인기 상품 목록 조회", description = "카메라 점수 및 실구매율 기반 인기 상품 3개를 조회합니다.")
+    public List<ItemInfoResponse> itemFindPopularity(
+            @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
+                    Long popupId) {
+        return itemService.findItemsPopularity(popupId);
+    }
 }

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -3,7 +3,6 @@ package com.lgcns.domain.item.internalApi;
 import com.lgcns.domain.item.client.dto.request.ItemIdsForPaymentRequest;
 import com.lgcns.domain.item.client.dto.response.ItemForPaymentResponse;
 import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
-import com.lgcns.domain.item.dto.response.ItemTrendingResponse;
 import com.lgcns.domain.item.service.ItemService;
 import com.lgcns.global.common.response.SliceResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,9 +62,9 @@ public class ItemInternalController {
 
     @GetMapping("/popularity")
     @Operation(summary = "인기 상품 목록 조회", description = "카메라 점수 및 실구매율 기반 인기 상품 3개를 조회합니다.")
-    public List<ItemTrendingResponse> itemFindPopularity(
+    public List<ItemInfoResponse> findItemPopularity(
             @Parameter(description = "팝업 ID", example = "1") @PathVariable(name = "popupId")
                     Long popupId) {
-        return itemService.getTrendingItems(popupId);
+        return itemService.getTrendingItemsByUser(popupId);
     }
 }

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -38,7 +38,9 @@ public interface ItemService {
     List<ItemForPaymentResponse> findItemsForPayment(
             Long popupId, ItemIdsForPaymentRequest request);
 
-    List<ItemTrendingResponse> getTrendingItems(Long popupId);
+    List<ItemTrendingResponse> getTrendingItemsByManager(Long popupId);
+
+    List<ItemInfoResponse> getTrendingItemsByUser(Long popupId);
 
     List<Long> findTargetPopupIds();
 

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -47,6 +47,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 public class ItemServiceImpl implements ItemService {
 
+    private static final int HOT_ITEMS_LIMIT = 3;
     private final ItemRepository itemRepository;
     private final PopupRepository popupRepository;
     private final ManagerUtil managerUtil;

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -228,7 +228,7 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
-    public List<ItemTrendingResponse> getTrendingItems(Long popupId) {
+    public List<ItemTrendingResponse> getTrendingItemsByManager(Long popupId) {
         final Manager currentManager = managerUtil.getCurrentManager();
         final Popup popup = findPopupById(popupId);
 
@@ -238,6 +238,24 @@ public class ItemServiceImpl implements ItemService {
                 itemRepository.findTopItemsByPopupId(popupId, DASHBOARD_HOT_ITEM_SIZE);
 
         return topItems.isEmpty() ? Collections.emptyList() : convertToResponse(topItems);
+    }
+
+    @Override
+    public List<ItemInfoResponse> getTrendingItemsByUser(Long popupId) {
+        findPopupById(popupId);
+
+        List<Item> topItems =
+                itemRepository.findTopItemsByPopupId(popupId, DASHBOARD_HOT_ITEM_SIZE);
+
+        return topItems.stream()
+                .map(
+                        item ->
+                                ItemInfoResponse.of(
+                                        item.getId(),
+                                        item.getName(),
+                                        item.getImageUrl(),
+                                        item.getPrice()))
+                .toList();
     }
 
     @Override

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -883,7 +883,8 @@ class ItemServiceTest extends IntegrationTest {
             Long popupId = popup.getId();
 
             // when
-            List<ItemTrendingResponse> trendingItems = itemService.getTrendingItems(popupId);
+            List<ItemTrendingResponse> trendingItems =
+                    itemService.getTrendingItemsByManager(popupId);
 
             // then
             AssertionsForClassTypes.assertThat(trendingItems).isNotNull();
@@ -903,7 +904,8 @@ class ItemServiceTest extends IntegrationTest {
             Long popupId = otherPopup.getId();
 
             // when
-            List<ItemTrendingResponse> trendingItems = itemService.getTrendingItems(popupId);
+            List<ItemTrendingResponse> trendingItems =
+                    itemService.getTrendingItemsByManager(popupId);
 
             // then
             AssertionsForClassTypes.assertThat(trendingItems).isNotNull();
@@ -917,7 +919,8 @@ class ItemServiceTest extends IntegrationTest {
             setAuthentication(otherManager);
 
             // when & then
-            AssertionsForClassTypes.assertThatThrownBy(() -> itemService.getTrendingItems(popupId))
+            AssertionsForClassTypes.assertThatThrownBy(
+                            () -> itemService.getTrendingItemsByManager(popupId))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
         }
@@ -929,7 +932,85 @@ class ItemServiceTest extends IntegrationTest {
 
             // when & then
             AssertionsForClassTypes.assertThatThrownBy(
-                            () -> itemService.getTrendingItems(nonExistentPopupId))
+                            () -> itemService.getTrendingItemsByManager(nonExistentPopupId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    class 내부용_인기_상품_조회할_때 {
+        @BeforeEach
+        void setUp() {
+            item1 =
+                    Item.createItem(
+                            popup, "지수 포토카드", "https://bucket/jisoo.jpg", 5000, 50, 5, "a1");
+            item2 =
+                    Item.createItem(
+                            popup, "제니 포토카드", "https://bucket/jennie.jpg", 15000, 100, 10, "a2");
+            item3 =
+                    Item.createItem(
+                            popup, "로제 포토카드", "https://bucket/rose.jpg", 15000, 100, 10, "b1");
+
+            itemRepository.save(item1);
+            itemRepository.save(item2);
+            itemRepository.save(item3);
+        }
+
+        @BeforeEach
+        void setUpForTrendingItems() {
+            item1.updatePopularityScore(100);
+            item2.updatePopularityScore(80);
+            item3.updatePopularityScore(60);
+            item1.decreaseStockAndIncreaseSales(50);
+            item2.decreaseStockAndIncreaseSales(30);
+            item3.decreaseStockAndIncreaseSales(20);
+            itemRepository.saveAll(List.of(item1, item2, item3));
+        }
+
+        @Test
+        void 정상적으로_인기_상품_TOP3를_조회한다() {
+            // given
+            Long popupId = popup.getId();
+
+            // when
+            List<ItemTrendingResponse> trendingItems =
+                    itemService.getTrendingItemsByManager(popupId);
+
+            // then
+            AssertionsForClassTypes.assertThat(trendingItems).isNotNull();
+            AssertionsForClassTypes.assertThat(trendingItems.size()).isEqualTo(3); // 3개 상품만 있음
+
+            AssertionsForClassTypes.assertThat(trendingItems.get(0).itemId())
+                    .isEqualTo(item1.getId());
+            AssertionsForClassTypes.assertThat(trendingItems.get(1).itemId())
+                    .isEqualTo(item2.getId());
+            AssertionsForClassTypes.assertThat(trendingItems.get(2).itemId())
+                    .isEqualTo(item3.getId());
+        }
+
+        @Test
+        void 상품_분석_데이터가_없으면_빈_리스트를_반환한다() {
+            // given
+            Long popupId = otherPopup.getId();
+
+            // when
+            List<ItemTrendingResponse> trendingItems =
+                    itemService.getTrendingItemsByManager(popupId);
+
+            // then
+            AssertionsForClassTypes.assertThat(trendingItems).isNotNull();
+            AssertionsForClassTypes.assertThat(trendingItems.size()).isEqualTo(0);
+        }
+
+        @Test
+        void 존재하지_않는_팝업에_대해_인기_상품을_조회하면_예외가_발생한다() {
+            // given
+            Long nonExistentPopupId = 9999L;
+
+            // when & then
+            AssertionsForClassTypes.assertThatThrownBy(
+                            () -> itemService.getTrendingItemsByManager(nonExistentPopupId))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
         }

--- a/src/test/java/com/lgcns/domain/visitorStats/service/VisitorStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/visitorStats/service/VisitorStatsServiceTest.java
@@ -331,7 +331,7 @@ class VisitorStatsServiceTest extends IntegrationTest {
 
         @Test
         @Transactional
-        void 방문자가_없으면_팝업_ID_방문자_통계_조회에_성공한다() {
+        void 방문자가_없으면_빈_리스트_반환에_성공한다() {
             // given
             Long popup2Id = popup2.getId();
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-232]

---
## 📌 작업 내용 및 특이사항

- 유저 서버에서 인기 상품 목록을 조회할 수 있도록 내부 API를 구현했습니다.
- 기존 ItemInfoResponse와 ItemRepository의 findTopItemsByPopupId 메서드를 재사용했습니다.
- 기존 getTrendingItems는 매니저 전용으로 매니저 인가가 필요하므로, 매니저 전용 getTrendingItemsByManager와 인가 없이 내부 호출이 가능한 getTrendingItemsByUser로 기능을 분리했습니다.
- 내부용 인기 상품 조회 테스트 코드를 구현했습니다.

---
## 📚 참고사항


[LCR-232]: https://lgcns-retail.atlassian.net/browse/LCR-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ