### PR TITLE
feat: HTTP 요청 & 응답 로깅 필터 도입

### DIFF
--- a/src/main/java/com/lgcns/global/logging/dto/HttpRequestLogInfo.java
+++ b/src/main/java/com/lgcns/global/logging/dto/HttpRequestLogInfo.java
@@ -1,0 +1,35 @@
+package com.lgcns.global.logging.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcns.global.logging.filter.wrapper.RequestWrapper;
+import org.slf4j.MDC;
+
+public record HttpRequestLogInfo(
+        String traceId,
+        String requestMethod,
+        String requestUri,
+        String xAmznTraceId,
+        String userAgent) {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static HttpRequestLogInfo from(RequestWrapper requestWrapper) {
+        String queryString = requestWrapper.getQueryString();
+        String traceId = MDC.get("traceId");
+        String requestMethod = requestWrapper.getMethod();
+        String requestUri =
+                requestWrapper.getRequestURI() + (queryString == null ? "" : "?" + queryString);
+        String xAmznTraceId = requestWrapper.getHeader("x-amzn-trace-id");
+        String userAgent = requestWrapper.getHeader("user-agent");
+
+        return new HttpRequestLogInfo(traceId, requestMethod, requestUri, xAmznTraceId, userAgent);
+    }
+
+    public String toJson() {
+        try {
+            return objectMapper.writeValueAsString(this).replace("\\", "");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/lgcns/global/logging/dto/HttpResponseLogInfo.java
+++ b/src/main/java/com/lgcns/global/logging/dto/HttpResponseLogInfo.java
@@ -1,0 +1,65 @@
+package com.lgcns.global.logging.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public record HttpResponseLogInfo(String traceId, String responseBody, Integer responseStatus) {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static HttpResponseLogInfo from(ContentCachingResponseWrapper response)
+            throws IOException {
+        String traceId = MDC.get("traceId");
+        String responseBody =
+                getContent(response.getContentType(), response.getContentInputStream());
+        Integer responseStatus = response.getStatus();
+
+        return new HttpResponseLogInfo(traceId, responseBody, responseStatus);
+    }
+
+    private static String getContent(String contentType, InputStream inputStream)
+            throws IOException {
+        boolean visible =
+                isVisible(
+                        MediaType.valueOf(contentType == null ? "application/json" : contentType));
+        if (visible) {
+            byte[] content = StreamUtils.copyToByteArray(inputStream);
+            if (content.length > 0) {
+                return new String(content, 0, Math.min(content.length, 5120));
+            } else {
+                return "";
+            }
+        } else {
+            return "BINARY";
+        }
+    }
+
+    private static boolean isVisible(MediaType mediaType) {
+        final List<MediaType> VISIBLE_TYPES =
+                Arrays.asList(
+                        MediaType.valueOf("text/*"),
+                        MediaType.APPLICATION_FORM_URLENCODED,
+                        MediaType.APPLICATION_JSON,
+                        MediaType.APPLICATION_XML,
+                        MediaType.valueOf("application/*+json"),
+                        MediaType.valueOf("application/*+xml"),
+                        MediaType.MULTIPART_FORM_DATA);
+
+        return VISIBLE_TYPES.stream().anyMatch(visibleType -> visibleType.includes(mediaType));
+    }
+
+    public String toJson() {
+        try {
+            return objectMapper.writeValueAsString(this).replace("\\", "");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/lgcns/global/logging/filter/HttpLoggingFilter.java
+++ b/src/main/java/com/lgcns/global/logging/filter/HttpLoggingFilter.java
@@ -1,0 +1,58 @@
+package com.lgcns.global.logging.filter;
+
+import com.lgcns.global.logging.dto.HttpRequestLogInfo;
+import com.lgcns.global.logging.dto.HttpResponseLogInfo;
+import com.lgcns.global.logging.filter.wrapper.RequestWrapper;
+import com.lgcns.global.logging.filter.wrapper.ResponseWrapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Slf4j
+@Component
+public class HttpLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        MDC.put("traceId", UUID.randomUUID().toString());
+        if (isAsyncDispatch(request)) {
+            filterChain.doFilter(request, response);
+        } else {
+            doFilterWrapped(
+                    new RequestWrapper(request), new ResponseWrapper(response), filterChain);
+        }
+        MDC.clear();
+    }
+
+    protected void doFilterWrapped(
+            RequestWrapper request, ContentCachingResponseWrapper response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            logRequest(request);
+            filterChain.doFilter(request, response);
+        } finally {
+            logResponse(response);
+            response.copyBodyToResponse();
+        }
+    }
+
+    private static void logRequest(RequestWrapper request) {
+        HttpRequestLogInfo httpLogInfo = HttpRequestLogInfo.from(request);
+        log.info(httpLogInfo.toJson());
+    }
+
+    private static void logResponse(ContentCachingResponseWrapper response) throws IOException {
+        HttpResponseLogInfo httpLogInfo = HttpResponseLogInfo.from(response);
+        log.info(httpLogInfo.toJson());
+    }
+}

--- a/src/main/java/com/lgcns/global/logging/filter/wrapper/RequestWrapper.java
+++ b/src/main/java/com/lgcns/global/logging/filter/wrapper/RequestWrapper.java
@@ -1,0 +1,54 @@
+package com.lgcns.global.logging.filter.wrapper;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.util.StreamUtils;
+
+public class RequestWrapper extends HttpServletRequestWrapper {
+
+    private final byte[] cachedInputStream;
+
+    public RequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        InputStream requestInputStream = request.getInputStream();
+        this.cachedInputStream = StreamUtils.copyToByteArray(requestInputStream);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new ServletInputStream() {
+            private final InputStream cachedBodyInputStream =
+                    new ByteArrayInputStream(cachedInputStream);
+
+            @Override
+            public boolean isFinished() {
+                try {
+                    return cachedBodyInputStream.available() == 0;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener listener) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int read() throws IOException {
+                return cachedBodyInputStream.read();
+            }
+        };
+    }
+}

--- a/src/main/java/com/lgcns/global/logging/filter/wrapper/ResponseWrapper.java
+++ b/src/main/java/com/lgcns/global/logging/filter/wrapper/ResponseWrapper.java
@@ -1,0 +1,10 @@
+package com.lgcns.global.logging.filter.wrapper;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public class ResponseWrapper extends ContentCachingResponseWrapper {
+    public ResponseWrapper(HttpServletResponse response) {
+        super(response);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-340]

---
## 📌 작업 내용 및 특이사항

- **`RequestWrapper`**
  - `HttpServletRequestWrapper`를 상속해 구현했습니다.
  - `HttpServletRequest#getInputStream()`이 한 번만 읽히는 Servlet API 특성상, 필터나 인터셉터에서 바디를 로깅·검사한 뒤 컨트롤러에서 재사용하려면 캐싱이 필요했습니다.
  - 생성자에서 바디 전체를 `byte[]`로 저장하고, `getInputStream()` 호출 시마다 새로운 `ByteArrayInputStream`을 반환해 다중 읽기를 지원했습니다.

- **`ResponseWrapper`**  
  - Spring의 `ContentCachingResponseWrapper`를 상속해 구현했습니다.
  - 응답 바디는 `HttpServletResponse#getOutputStream()` 호출 시 직접 쓰여 읽기가 불가능하므로, 캐싱 래퍼가 필요했습니다.
  - 필터 체인 실행 후 캐싱된 바디를 `copyBodyToResponse()`로 원본 `HttpServletResponse`에 복원했습니다.

- **`HttpRequestLogInfo`**
  - 요청 메타데이터(`traceId`, HTTP 메서드, 요청 URI, `x-amzn-trace-id`, `User-Agent`)를 일관된 포맷으로 로깅하기 위해 구현했습니다.  
  - **필드 설명**  
    - `traceId` — MDC에 UUID로 저장된 요청 단위 고유 ID (로그 연관 검색용)  
    - `requestMethod` / `requestUri` — HTTP 메서드와 URI(쿼리스트링 포함)  
    - `xAmznTraceId` — AWS X-Ray 분산 트레이스 헤더 (`null` 가능)  
    - `userAgent` — 클라이언트 브라우저/앱 정보  
  - **`toJson()`**  
    - `ObjectMapper.writeValueAsString(this)`로 JSON 직렬화 후 `.replace("\\", "")` 처리해 슬래시 이스케이프 없이 가독성을 높였습니다.

- **`HttpResponseLogInfo`**
  - 응답 정보를 일관된 포맷으로 로깅하기 위해 구현했습니다.  
  - **필드 설명**  
    - `traceId` — 요청과 매칭할 MDC UUID (로그 연관 검색용)  
    - `responseBody` — `getContentType()` 기반으로 JSON/Text/XML 등 가시 콘텐츠만 최대 5KB까지 로깅, 그 외는 `"BINARY"` 처리  
    - `responseStatus` — 실제 HTTP 상태 코드 (200, 400, 500 등)  
  - **`toJson()`**  
    - `ObjectMapper.writeValueAsString(this)`로 JSON 직렬화 후 `.replace("\\", "")` 처리해 슬래시 이스케이프 없이 가독성을 높였습니다.

- **`HttpLoggingFilter`**
  -  `OncePerRequestFilter`를 확장해 `MDC`에 UUID `traceId`를 설정하고, 동기/비동기 분기를 처리한 뒤 `RequestWrapper`/`ResponseWrapper`를 적용하여 요청·응답을 로깅한 후 응답 바디를 복원하도록 했습니다.
    - 1. MDC.put("traceId", UUID…) — 모든 로그에 동일한 traceId 부여
    - 2. 동기/비동기 요청 분기 후, 래퍼 적용
    - 3. logRequest() — HttpRequestLogInfo.from(...)
    - 4. 실제 서비스 로직 수행
    - 5. logResponse() — HttpResponseLogInfo.from(...)
    - 6. copyBodyToResponse()로 응답 바디 복원
    - 7. MDC.clear()로 thread-local 정리

---
## 📚 참고사항

- https://prohannah.tistory.com/182
- 다음 기술 블로그 읽어보시면 좋을 듯 합니다!

[LCR-340]: https://lgcns-retail.atlassian.net/browse/LCR-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ