### PR TITLE
fix: 알림 테이블 인기도 enum 값 대문자화 마이그레이션 스크립트 추가

### DIFF
--- a/src/main/resources/db/migration/V31_1__update_notification_popularity_data.sql
+++ b/src/main/resources/db/migration/V31_1__update_notification_popularity_data.sql
@@ -1,0 +1,3 @@
+UPDATE notification
+SET popularity = UPPER(popularity)
+WHERE popularity IN ('hot','normal');


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-343]

---
## 📌 작업 내용 및 특이사항

- notification 테이블 인기도(popularity) enum 값을 소문자에서 대문자(HOT/NORMAL)로 변환하는 DB 마이그레이션(V31_1__update_notification_popularity_data.sql)을 추가하여, 기존 소문자 값으로 발생하던 클라이언트 호출 오류를 수정했습니다.


[LCR-343]: https://lgcns-retail.atlassian.net/browse/LCR-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ