### PR TITLE
feat: 예약자 수 분석 스케줄링 구현

### DIFF
--- a/src/main/java/com/lgcns/domain/reservationStats/client/ReservationServiceClient.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/client/ReservationServiceClient.java
@@ -1,7 +1,9 @@
 package com.lgcns.domain.reservationStats.client;
 
 import com.lgcns.domain.reservationStats.client.dto.DailyMemberReservationCountResponse;
+import com.lgcns.domain.reservationStats.client.dto.DayOfWeekReservationStatsResponse;
 import com.lgcns.global.config.feign.FeignConfig;
+import java.util.Map;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,4 +17,7 @@ public interface ReservationServiceClient {
     @GetMapping("/internal/{popupId}/daily-count")
     DailyMemberReservationCountResponse findDailyMemberReservationCount(
             @PathVariable(name = "popupId") Long popupId);
+
+    @GetMapping("/internal/day-of-week-count")
+    Map<Long, DayOfWeekReservationStatsResponse> getAllDayOfWeekReservationStats();
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/client/dto/DayOfWeekReservationStatsResponse.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/client/dto/DayOfWeekReservationStatsResponse.java
@@ -1,0 +1,33 @@
+package com.lgcns.domain.reservationStats.client.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DayOfWeekReservationStatsResponse(
+        @Schema(description = "팝업 ID", example = "1") Long popupId,
+        @Schema(description = "월요일 예약 수", example = "10") int mondayCount,
+        @Schema(description = "화요일 예약 수", example = "12") int tuesdayCount,
+        @Schema(description = "수요일 예약 수", example = "8") int wednesdayCount,
+        @Schema(description = "목요일 예약 수", example = "15") int thursdayCount,
+        @Schema(description = "금요일 예약 수", example = "20") int fridayCount,
+        @Schema(description = "토요일 예약 수", example = "25") int saturdayCount,
+        @Schema(description = "일요일 예약 수", example = "18") int sundayCount) {
+    public static DayOfWeekReservationStatsResponse of(
+            Long popupId,
+            int mondayCount,
+            int tuesdayCount,
+            int wednesdayCount,
+            int thursdayCount,
+            int fridayCount,
+            int saturdayCount,
+            int sundayCount) {
+        return new DayOfWeekReservationStatsResponse(
+                popupId,
+                mondayCount,
+                tuesdayCount,
+                wednesdayCount,
+                thursdayCount,
+                fridayCount,
+                saturdayCount,
+                sundayCount);
+    }
+}

--- a/src/main/java/com/lgcns/domain/reservationStats/exception/ReservationStatsErrorCode.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/exception/ReservationStatsErrorCode.java
@@ -1,0 +1,24 @@
+package com.lgcns.domain.reservationStats.exception;
+
+import com.lgcns.global.error.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum ReservationStatsErrorCode implements ErrorCode {
+    RESERVATION_SERVICE_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "예약 서비스에 연결할 수 없습니다."),
+    RESERVATION_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예약 서비스에서 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/lgcns/domain/reservationStats/exception/ReservationStatsErrorCode.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/exception/ReservationStatsErrorCode.java
@@ -2,8 +2,10 @@ package com.lgcns.domain.reservationStats.exception;
 
 import com.lgcns.global.error.exception.ErrorCode;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @AllArgsConstructor
 public enum ReservationStatsErrorCode implements ErrorCode {
     RESERVATION_SERVICE_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "예약 서비스에 연결할 수 없습니다."),
@@ -11,14 +13,4 @@ public enum ReservationStatsErrorCode implements ErrorCode {
 
     private final HttpStatus httpStatus;
     private final String message;
-
-    @Override
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/repository/DayOfWeekReservationCountRepository.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/repository/DayOfWeekReservationCountRepository.java
@@ -1,9 +1,9 @@
 package com.lgcns.domain.reservationStats.repository;
 
 import com.lgcns.domain.reservationStats.domain.DayOfWeekReservationCount;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,28 +12,6 @@ public interface DayOfWeekReservationCountRepository
 
     Optional<DayOfWeekReservationCount> findByPopupId(Long popupId);
 
-    @Modifying
-    @Query(
-            "UPDATE DayOfWeekReservationCount d SET "
-                    + "d.mondayCount = :mondayCount, "
-                    + "d.tuesdayCount = :tuesdayCount, "
-                    + "d.wednesdayCount = :wednesdayCount, "
-                    + "d.thursdayCount = :thursdayCount, "
-                    + "d.fridayCount = :fridayCount, "
-                    + "d.saturdayCount = :saturdayCount, "
-                    + "d.sundayCount = :sundayCount "
-                    + "WHERE d.popupId = :popupId")
-    void updateDayOfWeekCounts(
-            @Param("popupId") Long popupId,
-            @Param("mondayCount") int mondayCount,
-            @Param("tuesdayCount") int tuesdayCount,
-            @Param("wednesdayCount") int wednesdayCount,
-            @Param("thursdayCount") int thursdayCount,
-            @Param("fridayCount") int fridayCount,
-            @Param("saturdayCount") int saturdayCount,
-            @Param("sundayCount") int sundayCount);
-
-    void deleteByPopupId(Long popupId);
-
-    boolean existsByPopupId(Long popupId);
+    @Query("SELECT popupId FROM DayOfWeekReservationCount WHERE popupId IN :popupIds")
+    List<Long> findExistingPopupIds(@Param("popupIds") List<Long> popupIds);
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/repository/DayOfWeekReservationCountRepository.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/repository/DayOfWeekReservationCountRepository.java
@@ -3,9 +3,37 @@ package com.lgcns.domain.reservationStats.repository;
 import com.lgcns.domain.reservationStats.domain.DayOfWeekReservationCount;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DayOfWeekReservationCountRepository
         extends JpaRepository<DayOfWeekReservationCount, Long> {
 
     Optional<DayOfWeekReservationCount> findByPopupId(Long popupId);
+
+    @Modifying
+    @Query(
+            "UPDATE DayOfWeekReservationCount d SET "
+                    + "d.mondayCount = :mondayCount, "
+                    + "d.tuesdayCount = :tuesdayCount, "
+                    + "d.wednesdayCount = :wednesdayCount, "
+                    + "d.thursdayCount = :thursdayCount, "
+                    + "d.fridayCount = :fridayCount, "
+                    + "d.saturdayCount = :saturdayCount, "
+                    + "d.sundayCount = :sundayCount "
+                    + "WHERE d.popupId = :popupId")
+    void updateDayOfWeekCounts(
+            @Param("popupId") Long popupId,
+            @Param("mondayCount") int mondayCount,
+            @Param("tuesdayCount") int tuesdayCount,
+            @Param("wednesdayCount") int wednesdayCount,
+            @Param("thursdayCount") int thursdayCount,
+            @Param("fridayCount") int fridayCount,
+            @Param("saturdayCount") int saturdayCount,
+            @Param("sundayCount") int sundayCount);
+
+    void deleteByPopupId(Long popupId);
+
+    boolean existsByPopupId(Long popupId);
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/scheduler/DayOfWeekReservationStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/scheduler/DayOfWeekReservationStatsScheduler.java
@@ -1,0 +1,53 @@
+package com.lgcns.domain.reservationStats.scheduler;
+
+import com.lgcns.domain.reservationStats.service.ReservationStatsService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DayOfWeekReservationStatsScheduler {
+
+    private final ReservationStatsService reservationStatsService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateDayOfWeekReservationStats() {
+        try {
+            updateStats();
+        } catch (Exception e) {
+            log.error("요일별 예약 통계 업데이트 스케줄러 실패: {}", e.getMessage());
+            scheduleRetry();
+        }
+    }
+
+    private void updateStats() {
+        reservationStatsService.updateAllDayOfWeekReservationStats();
+    }
+
+    private void scheduleRetry() {
+        // 10분 후 첫 번째 재시도
+        CompletableFuture.delayedExecutor(10, TimeUnit.MINUTES).execute(() -> executeRetry(1));
+    }
+
+    private void executeRetry(int attemptNumber) {
+        try {
+            updateStats();
+            log.info("요일별 예약 통계 업데이트 재시도 {} 성공", attemptNumber);
+        } catch (Exception e) {
+            log.error("요일별 예약 통계 업데이트 재시도 {} 실패: {}", attemptNumber, e.getMessage());
+
+            if (attemptNumber < 2) {
+                // 10분 후 마지막
+                CompletableFuture.delayedExecutor(10, TimeUnit.MINUTES)
+                        .execute(() -> executeRetry(attemptNumber + 1));
+            } else {
+                log.error("요일별 예약 통계 업데이트 모든 재시도 실패");
+            }
+        }
+    }
+}

--- a/src/main/java/com/lgcns/domain/reservationStats/scheduler/DayOfWeekReservationStatsScheduler.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/scheduler/DayOfWeekReservationStatsScheduler.java
@@ -4,13 +4,11 @@ import com.lgcns.domain.reservationStats.service.ReservationStatsService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class DayOfWeekReservationStatsScheduler {
 
     private final ReservationStatsService reservationStatsService;
@@ -20,7 +18,6 @@ public class DayOfWeekReservationStatsScheduler {
         try {
             updateStats();
         } catch (Exception e) {
-            log.error("요일별 예약 통계 업데이트 스케줄러 실패: {}", e.getMessage());
             scheduleRetry();
         }
     }
@@ -30,23 +27,16 @@ public class DayOfWeekReservationStatsScheduler {
     }
 
     private void scheduleRetry() {
-        // 10분 후 첫 번째 재시도
         CompletableFuture.delayedExecutor(10, TimeUnit.MINUTES).execute(() -> executeRetry(1));
     }
 
     private void executeRetry(int attemptNumber) {
         try {
             updateStats();
-            log.info("요일별 예약 통계 업데이트 재시도 {} 성공", attemptNumber);
         } catch (Exception e) {
-            log.error("요일별 예약 통계 업데이트 재시도 {} 실패: {}", attemptNumber, e.getMessage());
-
             if (attemptNumber < 2) {
-                // 10분 후 마지막
                 CompletableFuture.delayedExecutor(10, TimeUnit.MINUTES)
                         .execute(() -> executeRetry(attemptNumber + 1));
-            } else {
-                log.error("요일별 예약 통계 업데이트 모든 재시도 실패");
             }
         }
     }

--- a/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsService.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsService.java
@@ -5,4 +5,6 @@ import com.lgcns.domain.reservationStats.dto.response.ReservationStatsResponse;
 public interface ReservationStatsService {
 
     ReservationStatsResponse getReservationStats(Long popupId);
+
+    void updateAllDayOfWeekReservationStats();
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsServiceImpl.java
@@ -6,23 +6,28 @@ import com.lgcns.domain.popup.exception.PopupErrorCode;
 import com.lgcns.domain.popup.repository.PopupRepository;
 import com.lgcns.domain.reservationStats.client.ReservationServiceClient;
 import com.lgcns.domain.reservationStats.client.dto.DailyMemberReservationCountResponse;
+import com.lgcns.domain.reservationStats.client.dto.DayOfWeekReservationStatsResponse;
 import com.lgcns.domain.reservationStats.domain.DayOfWeekReservationCount;
 import com.lgcns.domain.reservationStats.dto.response.DayOfWeek;
 import com.lgcns.domain.reservationStats.dto.response.DayOfWeekReservationCountResponse;
 import com.lgcns.domain.reservationStats.dto.response.ReservationStatsResponse;
+import com.lgcns.domain.reservationStats.exception.ReservationStatsErrorCode;
 import com.lgcns.domain.reservationStats.repository.DayOfWeekReservationCountRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ReservationStatsServiceImpl implements ReservationStatsService {
 
     private final PopupRepository popupRepository;
@@ -47,6 +52,14 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
                 convertToChart(dayOfWeekReservationCountList);
 
         return ReservationStatsResponse.of(dailyCount, chart);
+    }
+
+    @Override
+    public void updateAllDayOfWeekReservationStats() {
+        List<Popup> allPopups = popupRepository.findAll();
+        Map<Long, DayOfWeekReservationStatsResponse> allStatsMap =
+                getAllDayOfWeekStatsFromReservationService();
+        processPopupStatsUpdate(allPopups, allStatsMap);
     }
 
     private Popup findPopupById(Long popupId) {
@@ -85,5 +98,72 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
         }
 
         return chart;
+    }
+
+    private Map<Long, DayOfWeekReservationStatsResponse>
+            getAllDayOfWeekStatsFromReservationService() {
+        try {
+            return reservationServiceClient.getAllDayOfWeekReservationStats();
+        } catch (feign.RetryableException e) {
+            log.error("예약 서비스 연결 실패: {}", e.getMessage());
+            throw new CustomException(
+                    ReservationStatsErrorCode.RESERVATION_SERVICE_CONNECTION_FAILED);
+        } catch (Exception e) {
+            log.error("예약 서비스 오류: {}", e.getMessage());
+            throw new CustomException(ReservationStatsErrorCode.RESERVATION_SERVICE_ERROR);
+        }
+    }
+
+    private void processPopupStatsUpdate(
+            List<Popup> allPopups, Map<Long, DayOfWeekReservationStatsResponse> allStatsMap) {
+
+        for (Popup popup : allPopups) {
+            try {
+                DayOfWeekReservationStatsResponse stats = allStatsMap.get(popup.getId());
+                updateSinglePopupStats(popup.getId(), stats);
+            } catch (Exception e) {
+                log.error("팝업 ID {}의 통계 업데이트 실패: {}", popup.getId(), e.getMessage());
+            }
+        }
+    }
+
+    private void updateSinglePopupStats(Long popupId, DayOfWeekReservationStatsResponse stats) {
+        if (stats == null) {
+            return;
+        }
+
+        if (dayOfWeekReservationCountRepository.existsByPopupId(popupId)) {
+            updateExistingRecordDirectly(popupId, stats);
+        } else {
+            createNewRecord(stats);
+        }
+    }
+
+    private void updateExistingRecordDirectly(
+            Long popupId, DayOfWeekReservationStatsResponse stats) {
+        dayOfWeekReservationCountRepository.updateDayOfWeekCounts(
+                popupId,
+                stats.mondayCount(),
+                stats.tuesdayCount(),
+                stats.wednesdayCount(),
+                stats.thursdayCount(),
+                stats.fridayCount(),
+                stats.saturdayCount(),
+                stats.sundayCount());
+    }
+
+    private void createNewRecord(DayOfWeekReservationStatsResponse stats) {
+        DayOfWeekReservationCount newRecord =
+                DayOfWeekReservationCount.createDayOfWeekReservationCount(
+                        stats.popupId(),
+                        stats.mondayCount(),
+                        stats.tuesdayCount(),
+                        stats.wednesdayCount(),
+                        stats.thursdayCount(),
+                        stats.fridayCount(),
+                        stats.saturdayCount(),
+                        stats.sundayCount());
+
+        dayOfWeekReservationCountRepository.save(newRecord);
     }
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsServiceImpl.java
@@ -15,10 +15,9 @@ import com.lgcns.domain.reservationStats.exception.ReservationStatsErrorCode;
 import com.lgcns.domain.reservationStats.repository.DayOfWeekReservationCountRepository;
 import com.lgcns.global.error.exception.CustomException;
 import com.lgcns.global.util.ManagerUtil;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +33,7 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
     private final DayOfWeekReservationCountRepository dayOfWeekReservationCountRepository;
     private final ManagerUtil managerUtil;
     private final ReservationServiceClient reservationServiceClient;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional(readOnly = true)
@@ -56,10 +56,14 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
 
     @Override
     public void updateAllDayOfWeekReservationStats() {
-        List<Popup> allPopups = popupRepository.findAll();
         Map<Long, DayOfWeekReservationStatsResponse> allStatsMap =
                 getAllDayOfWeekStatsFromReservationService();
-        processPopupStatsUpdate(allPopups, allStatsMap);
+
+        if (allStatsMap.isEmpty()) {
+            return;
+        }
+
+        bulkUpsertWithCaseWhen(allStatsMap);
     }
 
     private Popup findPopupById(Long popupId) {
@@ -114,35 +118,95 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
         }
     }
 
-    private void processPopupStatsUpdate(
-            List<Popup> allPopups, Map<Long, DayOfWeekReservationStatsResponse> allStatsMap) {
+    private void bulkUpsertWithCaseWhen(Map<Long, DayOfWeekReservationStatsResponse> allStatsMap) {
+        List<Long> popupIds = new ArrayList<>(allStatsMap.keySet());
+        List<Long> existingPopupIds =
+                dayOfWeekReservationCountRepository.findExistingPopupIds(popupIds);
 
-        for (Popup popup : allPopups) {
-            try {
-                DayOfWeekReservationStatsResponse stats = allStatsMap.get(popup.getId());
-                updateSinglePopupStats(popup.getId(), stats);
-            } catch (Exception e) {
-                log.error("팝업 ID {}의 통계 업데이트 실패: {}", popup.getId(), e.getMessage());
+        if (!existingPopupIds.isEmpty()) {
+            bulkUpdateExistingData(allStatsMap, existingPopupIds);
+        }
+
+        Set<Long> existingSet = new HashSet<>(existingPopupIds);
+        List<DayOfWeekReservationCount> newEntities =
+                allStatsMap.values().stream()
+                        .filter(stats -> !existingSet.contains(stats.popupId()))
+                        .map(this::createNewCount)
+                        .toList();
+
+        if (!newEntities.isEmpty()) {
+            dayOfWeekReservationCountRepository.saveAll(newEntities);
+        }
+
+        log.info(
+                "요일별 통계 벌크 업데이트 완료: 업데이트 {}개, 삽입 {}개", existingPopupIds.size(), newEntities.size());
+    }
+
+    private void bulkUpdateExistingData(
+            Map<Long, DayOfWeekReservationStatsResponse> allStatsMap, List<Long> existingPopupIds) {
+
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("UPDATE DayOfWeekReservationCount d SET ");
+
+        String[] fields = {
+            "mondayCount",
+            "tuesdayCount",
+            "wednesdayCount",
+            "thursdayCount",
+            "fridayCount",
+            "saturdayCount",
+            "sundayCount"
+        };
+
+        for (int i = 0; i < fields.length; i++) {
+            if (i > 0) jpql.append(", ");
+
+            jpql.append("d.").append(fields[i]).append(" = CASE d.popupId ");
+
+            for (Long popupId : existingPopupIds) {
+                DayOfWeekReservationStatsResponse stats = allStatsMap.get(popupId);
+                int value = getFieldValue(stats, fields[i]);
+                jpql.append("WHEN :popupId")
+                        .append(popupId)
+                        .append(" THEN ")
+                        .append(value)
+                        .append(" ");
             }
+
+            jpql.append("ELSE d.").append(fields[i]).append(" END");
         }
+
+        jpql.append(", d.updatedAt = CURRENT_TIMESTAMP ");
+        jpql.append("WHERE d.popupId IN :existingPopupIds");
+
+        Query query = entityManager.createQuery(jpql.toString());
+
+        // 파라미터 설정
+        for (Long popupId : existingPopupIds) {
+            query.setParameter("popupId" + popupId, popupId);
+        }
+        query.setParameter("existingPopupIds", existingPopupIds);
+
+        int updatedCount = query.executeUpdate();
+        log.debug("JPQL 벌크 업데이트 실행: {}개 레코드 업데이트", updatedCount);
     }
 
-    private void updateSinglePopupStats(Long popupId, DayOfWeekReservationStatsResponse stats) {
-        if (stats == null) {
-            return;
-        }
-
-        if (dayOfWeekReservationCountRepository.existsByPopupId(popupId)) {
-            updateExistingRecordDirectly(popupId, stats);
-        } else {
-            createNewRecord(stats);
-        }
+    private int getFieldValue(DayOfWeekReservationStatsResponse stats, String fieldName) {
+        return switch (fieldName) {
+            case "mondayCount" -> stats.mondayCount();
+            case "tuesdayCount" -> stats.tuesdayCount();
+            case "wednesdayCount" -> stats.wednesdayCount();
+            case "thursdayCount" -> stats.thursdayCount();
+            case "fridayCount" -> stats.fridayCount();
+            case "saturdayCount" -> stats.saturdayCount();
+            case "sundayCount" -> stats.sundayCount();
+            default -> throw new IllegalArgumentException("Unknown field: " + fieldName);
+        };
     }
 
-    private void updateExistingRecordDirectly(
-            Long popupId, DayOfWeekReservationStatsResponse stats) {
-        dayOfWeekReservationCountRepository.updateDayOfWeekCounts(
-                popupId,
+    private DayOfWeekReservationCount createNewCount(DayOfWeekReservationStatsResponse stats) {
+        return DayOfWeekReservationCount.createDayOfWeekReservationCount(
+                stats.popupId(),
                 stats.mondayCount(),
                 stats.tuesdayCount(),
                 stats.wednesdayCount(),
@@ -150,20 +214,5 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
                 stats.fridayCount(),
                 stats.saturdayCount(),
                 stats.sundayCount());
-    }
-
-    private void createNewRecord(DayOfWeekReservationStatsResponse stats) {
-        DayOfWeekReservationCount newRecord =
-                DayOfWeekReservationCount.createDayOfWeekReservationCount(
-                        stats.popupId(),
-                        stats.mondayCount(),
-                        stats.tuesdayCount(),
-                        stats.wednesdayCount(),
-                        stats.thursdayCount(),
-                        stats.fridayCount(),
-                        stats.saturdayCount(),
-                        stats.sundayCount());
-
-        dayOfWeekReservationCountRepository.save(newRecord);
     }
 }

--- a/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/service/ReservationStatsServiceImpl.java
@@ -19,14 +19,12 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Slf4j
 public class ReservationStatsServiceImpl implements ReservationStatsService {
 
     private final PopupRepository popupRepository;
@@ -109,11 +107,9 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
         try {
             return reservationServiceClient.getAllDayOfWeekReservationStats();
         } catch (feign.RetryableException e) {
-            log.error("예약 서비스 연결 실패: {}", e.getMessage());
             throw new CustomException(
                     ReservationStatsErrorCode.RESERVATION_SERVICE_CONNECTION_FAILED);
         } catch (Exception e) {
-            log.error("예약 서비스 오류: {}", e.getMessage());
             throw new CustomException(ReservationStatsErrorCode.RESERVATION_SERVICE_ERROR);
         }
     }
@@ -137,9 +133,6 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
         if (!newEntities.isEmpty()) {
             dayOfWeekReservationCountRepository.saveAll(newEntities);
         }
-
-        log.info(
-                "요일별 통계 벌크 업데이트 완료: 업데이트 {}개, 삽입 {}개", existingPopupIds.size(), newEntities.size());
     }
 
     private void bulkUpdateExistingData(
@@ -181,14 +174,12 @@ public class ReservationStatsServiceImpl implements ReservationStatsService {
 
         Query query = entityManager.createQuery(jpql.toString());
 
-        // 파라미터 설정
         for (Long popupId : existingPopupIds) {
             query.setParameter("popupId" + popupId, popupId);
         }
         query.setParameter("existingPopupIds", existingPopupIds);
 
-        int updatedCount = query.executeUpdate();
-        log.debug("JPQL 벌크 업데이트 실행: {}개 레코드 업데이트", updatedCount);
+        query.executeUpdate();
     }
 
     private int getFieldValue(DayOfWeekReservationStatsResponse stats, String fieldName) {

--- a/src/test/java/com/lgcns/domain/reservationStat/service/ReservationStatsServiceTest.java
+++ b/src/test/java/com/lgcns/domain/reservationStat/service/ReservationStatsServiceTest.java
@@ -1,7 +1,8 @@
 package com.lgcns.domain.reservationStat.service;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,7 +17,9 @@ import com.lgcns.domain.reservationStats.domain.DayOfWeekReservationCount;
 import com.lgcns.domain.reservationStats.dto.response.DayOfWeek;
 import com.lgcns.domain.reservationStats.dto.response.DayOfWeekReservationCountResponse;
 import com.lgcns.domain.reservationStats.dto.response.ReservationStatsResponse;
+import com.lgcns.domain.reservationStats.exception.ReservationStatsErrorCode;
 import com.lgcns.domain.reservationStats.repository.DayOfWeekReservationCountRepository;
+import com.lgcns.domain.reservationStats.scheduler.DayOfWeekReservationStatsScheduler;
 import com.lgcns.domain.reservationStats.service.ReservationStatsService;
 import com.lgcns.global.error.exception.CustomException;
 import java.time.LocalDate;
@@ -29,14 +32,17 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class ReservationStatsServiceTest extends IntegrationTest {
-    @Autowired private ReservationStatsService reservationStatsService;
 
+    @Autowired private ReservationStatsService reservationStatsService;
     @Autowired private ManagerRepository managerRepository;
     @Autowired private PopupRepository popupRepository;
     @Autowired private DayOfWeekReservationCountRepository dayOfWeekReservationCountRepository;
     @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private DayOfWeekReservationStatsScheduler scheduler;
 
     private Manager ownerManager;
     private Manager otherManager;
@@ -75,7 +81,64 @@ public class ReservationStatsServiceTest extends IntegrationTest {
     class 예약_통계를_조회할_때 {
 
         @Test
-        void 예약자가_있는_경우_예약_통계_조회에_성공한다() throws JsonProcessingException {
+        void 예약_통계_조회에_성공한다() throws JsonProcessingException {
+            // given
+            Long popupId = popup.getId();
+
+            String expectedResponse =
+                    objectMapper.writeValueAsString(Map.of("reservationCount", 10));
+            stubFindDailyMemberReservationCount(popupId, 200, expectedResponse);
+
+            dayOfWeekReservationCountRepository.save(
+                    DayOfWeekReservationCount.createDayOfWeekReservationCount(
+                            popupId, 5, 8, 12, 15, 20, 25, 18));
+
+            // when
+            ReservationStatsResponse result = reservationStatsService.getReservationStats(popupId);
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(result.reservedCount()).isEqualTo(10),
+                    () -> assertThat(result.chart()).hasSize(7),
+                    () ->
+                            assertThat(result.chart().get(0))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.MONDAY, 5)),
+                    () ->
+                            assertThat(result.chart().get(1))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.TUESDAY, 8)),
+                    () ->
+                            assertThat(result.chart().get(2))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.WEDNESDAY, 12)),
+                    () ->
+                            assertThat(result.chart().get(3))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.THURSDAY, 15)),
+                    () ->
+                            assertThat(result.chart().get(4))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.FRIDAY, 20)),
+                    () ->
+                            assertThat(result.chart().get(5))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.SATURDAY, 25)),
+                    () ->
+                            assertThat(result.chart().get(6))
+                                    .isEqualTo(
+                                            DayOfWeekReservationCountResponse.of(
+                                                    DayOfWeek.SUNDAY, 18)));
+        }
+
+        @Test
+        void 요일별_예약_통계가_없는_경우_모든_요일이_0으로_반환된다() throws JsonProcessingException {
             // given
             Long popupId = popup.getId();
 
@@ -83,104 +146,45 @@ public class ReservationStatsServiceTest extends IntegrationTest {
                     objectMapper.writeValueAsString(Map.of("reservationCount", 5));
             stubFindDailyMemberReservationCount(popupId, 200, expectedResponse);
 
-            dayOfWeekReservationCountRepository.save(
-                    DayOfWeekReservationCount.createDayOfWeekReservationCount(
-                            popupId, 1, 1, 1, 1, 1, 0, 0));
-
             // when
-            ReservationStatsResponse reservationStats =
-                    reservationStatsService.getReservationStats(popupId);
+            ReservationStatsResponse result = reservationStatsService.getReservationStats(popupId);
 
             // then
             Assertions.assertAll(
-                    () -> assertThat(reservationStats.reservedCount()).isEqualTo(5),
-                    () -> assertThat(reservationStats.chart().size()).isEqualTo(7),
+                    () -> assertThat(result.reservedCount()).isEqualTo(5),
+                    () -> assertThat(result.chart()).hasSize(7),
                     () ->
-                            assertThat(reservationStats.chart().get(0))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.MONDAY, 1)),
-                    () ->
-                            assertThat(reservationStats.chart().get(1))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.TUESDAY, 1)),
-                    () ->
-                            assertThat(reservationStats.chart().get(2))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.WEDNESDAY, 1)),
-                    () ->
-                            assertThat(reservationStats.chart().get(3))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.THURSDAY, 1)),
-                    () ->
-                            assertThat(reservationStats.chart().get(4))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.FRIDAY, 1)),
-                    () ->
-                            assertThat(reservationStats.chart().get(5))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.SATURDAY, 0)),
-                    () ->
-                            assertThat(reservationStats.chart().get(6))
-                                    .isEqualTo(
-                                            DayOfWeekReservationCountResponse.of(
-                                                    DayOfWeek.SUNDAY, 0)));
-        }
-
-        @Test
-        void 예약자가_없는_경우_예약_통계_조회에_성공한다() throws JsonProcessingException {
-            // given
-            Long popupId = popup.getId();
-
-            String expectedResponse =
-                    objectMapper.writeValueAsString(Map.of("reservationCount", 0));
-            stubFindDailyMemberReservationCount(popupId, 200, expectedResponse);
-
-            // when
-            ReservationStatsResponse reservationStats =
-                    reservationStatsService.getReservationStats(popupId);
-
-            // then
-            Assertions.assertAll(
-                    () -> assertThat(reservationStats.reservedCount()).isEqualTo(0),
-                    () -> assertThat(reservationStats.chart().size()).isEqualTo(7),
-                    () ->
-                            assertThat(reservationStats.chart().get(0))
+                            assertThat(result.chart().get(0))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.MONDAY, 0)),
                     () ->
-                            assertThat(reservationStats.chart().get(1))
+                            assertThat(result.chart().get(1))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.TUESDAY, 0)),
                     () ->
-                            assertThat(reservationStats.chart().get(2))
+                            assertThat(result.chart().get(2))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.WEDNESDAY, 0)),
                     () ->
-                            assertThat(reservationStats.chart().get(3))
+                            assertThat(result.chart().get(3))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.THURSDAY, 0)),
                     () ->
-                            assertThat(reservationStats.chart().get(4))
+                            assertThat(result.chart().get(4))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.FRIDAY, 0)),
                     () ->
-                            assertThat(reservationStats.chart().get(5))
+                            assertThat(result.chart().get(5))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.SATURDAY, 0)),
                     () ->
-                            assertThat(reservationStats.chart().get(6))
+                            assertThat(result.chart().get(6))
                                     .isEqualTo(
                                             DayOfWeekReservationCountResponse.of(
                                                     DayOfWeek.SUNDAY, 0)));
@@ -193,28 +197,244 @@ public class ReservationStatsServiceTest extends IntegrationTest {
             setAuthentication(otherManager);
 
             // when & then
-            Assertions.assertThrows(
-                    CustomException.class,
-                    () -> reservationStatsService.getReservationStats(popupId),
-                    PopupErrorCode.POPUP_UNAUTHORIZED.getMessage());
+            CustomException exception =
+                    assertThrows(
+                            CustomException.class,
+                            () -> reservationStatsService.getReservationStats(popupId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(PopupErrorCode.POPUP_UNAUTHORIZED);
         }
 
         @Test
         void 존재하지_않는_팝업에_대한_예약_통계_조회는_실패한다() {
             // given
-            Long popupId = -1L;
+            Long invalidPopupId = 99999L;
 
             // when & then
-            Assertions.assertThrows(
-                    CustomException.class,
-                    () -> reservationStatsService.getReservationStats(popupId),
-                    PopupErrorCode.POPUP_NOT_FOUND.getMessage());
+            CustomException exception =
+                    assertThrows(
+                            CustomException.class,
+                            () -> reservationStatsService.getReservationStats(invalidPopupId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(PopupErrorCode.POPUP_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    class 요일별_통계_테이블을_업데이트할_때 {
+
+        @Test
+        void 모든_팝업의_요일별_예약_통계_업데이트에_성공한다() throws JsonProcessingException {
+            // given
+            // 테스트를 위해 추가 팝업 생성
+            Popup popup2 =
+                    Popup.createPopup(
+                            ownerManager,
+                            "testPopup2",
+                            "https://bucket/이미지2.jpg",
+                            LocalDate.parse("2025-02-01"),
+                            LocalDate.parse("2025-02-28"),
+                            LocalDateTime.parse("2025-02-01T10:00:00"),
+                            LocalDateTime.parse("2025-02-28T20:00:00"),
+                            LocalTime.parse("10:00:00"),
+                            LocalTime.parse("20:00:00"),
+                            100,
+                            20,
+                            "서울특별시 강남구 테헤란로 456",
+                            "4층 B호",
+                            37.654321,
+                            127.654321);
+            popup2 = popupRepository.save(popup2);
+
+            Map<String, Object> statsData =
+                    Map.of(
+                            popup.getId().toString(),
+                                    Map.of(
+                                            "popupId", popup.getId(),
+                                            "mondayCount", 10,
+                                            "tuesdayCount", 12,
+                                            "wednesdayCount", 8,
+                                            "thursdayCount", 15,
+                                            "fridayCount", 20,
+                                            "saturdayCount", 25,
+                                            "sundayCount", 18),
+                            popup2.getId().toString(),
+                                    Map.of(
+                                            "popupId", popup2.getId(),
+                                            "mondayCount", 5,
+                                            "tuesdayCount", 7,
+                                            "wednesdayCount", 3,
+                                            "thursdayCount", 9,
+                                            "fridayCount", 11,
+                                            "saturdayCount", 13,
+                                            "sundayCount", 6));
+
+            String expectedResponse = objectMapper.writeValueAsString(statsData);
+            stubGetAllDayOfWeekReservationStats(200, expectedResponse);
+
+            // when
+            reservationStatsService.updateAllDayOfWeekReservationStats();
+
+            // then
+            DayOfWeekReservationCount popup1Stats =
+                    dayOfWeekReservationCountRepository.findByPopupId(popup.getId()).orElseThrow();
+            DayOfWeekReservationCount popup2Stats =
+                    dayOfWeekReservationCountRepository.findByPopupId(popup2.getId()).orElseThrow();
+
+            Assertions.assertAll(
+                    () -> assertThat(popup1Stats.getMondayCount()).isEqualTo(10),
+                    () -> assertThat(popup1Stats.getTuesdayCount()).isEqualTo(12),
+                    () -> assertThat(popup1Stats.getWednesdayCount()).isEqualTo(8),
+                    () -> assertThat(popup1Stats.getThursdayCount()).isEqualTo(15),
+                    () -> assertThat(popup1Stats.getFridayCount()).isEqualTo(20),
+                    () -> assertThat(popup1Stats.getSaturdayCount()).isEqualTo(25),
+                    () -> assertThat(popup1Stats.getSundayCount()).isEqualTo(18),
+                    () -> assertThat(popup2Stats.getMondayCount()).isEqualTo(5),
+                    () -> assertThat(popup2Stats.getTuesdayCount()).isEqualTo(7),
+                    () -> assertThat(popup2Stats.getWednesdayCount()).isEqualTo(3),
+                    () -> assertThat(popup2Stats.getThursdayCount()).isEqualTo(9),
+                    () -> assertThat(popup2Stats.getFridayCount()).isEqualTo(11),
+                    () -> assertThat(popup2Stats.getSaturdayCount()).isEqualTo(13),
+                    () -> assertThat(popup2Stats.getSundayCount()).isEqualTo(6));
+        }
+
+        @Test
+        void 기존_데이터가_있는_경우_업데이트에_성공한다() throws JsonProcessingException {
+            // given
+            dayOfWeekReservationCountRepository.save(
+                    DayOfWeekReservationCount.createDayOfWeekReservationCount(
+                            popup.getId(), 1, 2, 3, 4, 5, 6, 7));
+
+            Map<String, Object> statsData =
+                    Map.of(
+                            popup.getId().toString(),
+                            Map.of(
+                                    "popupId", popup.getId(),
+                                    "mondayCount", 15,
+                                    "tuesdayCount", 18,
+                                    "wednesdayCount", 22,
+                                    "thursdayCount", 25,
+                                    "fridayCount", 30,
+                                    "saturdayCount", 35,
+                                    "sundayCount", 28));
+
+            String expectedResponse = objectMapper.writeValueAsString(statsData);
+            stubGetAllDayOfWeekReservationStats(200, expectedResponse);
+
+            // when
+            reservationStatsService.updateAllDayOfWeekReservationStats();
+
+            // then
+            DayOfWeekReservationCount updatedStats =
+                    dayOfWeekReservationCountRepository.findByPopupId(popup.getId()).orElseThrow();
+
+            Assertions.assertAll(
+                    () -> assertThat(updatedStats.getMondayCount()).isEqualTo(15),
+                    () -> assertThat(updatedStats.getTuesdayCount()).isEqualTo(18),
+                    () -> assertThat(updatedStats.getWednesdayCount()).isEqualTo(22),
+                    () -> assertThat(updatedStats.getThursdayCount()).isEqualTo(25),
+                    () -> assertThat(updatedStats.getFridayCount()).isEqualTo(30),
+                    () -> assertThat(updatedStats.getSaturdayCount()).isEqualTo(35),
+                    () -> assertThat(updatedStats.getSundayCount()).isEqualTo(28));
+        }
+
+        @Test
+        void 예약_서비스에서_데이터가_없는_팝업은_업데이트되지_않는다() throws JsonProcessingException {
+            // given
+            // 테스트를 위해 추가 팝업 생성
+            Popup popup2 =
+                    Popup.createPopup(
+                            ownerManager,
+                            "testPopup2",
+                            "https://bucket/이미지2.jpg",
+                            LocalDate.parse("2025-02-01"),
+                            LocalDate.parse("2025-02-28"),
+                            LocalDateTime.parse("2025-02-01T10:00:00"),
+                            LocalDateTime.parse("2025-02-28T20:00:00"),
+                            LocalTime.parse("10:00:00"),
+                            LocalTime.parse("20:00:00"),
+                            100,
+                            20,
+                            "서울특별시 강남구 테헤란로 456",
+                            "4층 B호",
+                            37.654321,
+                            127.654321);
+            popup2 = popupRepository.save(popup2);
+
+            Map<String, Object> statsData =
+                    Map.of(
+                            popup2.getId().toString(),
+                            Map.of(
+                                    "popupId", popup2.getId(),
+                                    "mondayCount", 5,
+                                    "tuesdayCount", 7,
+                                    "wednesdayCount", 3,
+                                    "thursdayCount", 9,
+                                    "fridayCount", 11,
+                                    "saturdayCount", 13,
+                                    "sundayCount", 6));
+
+            String expectedResponse = objectMapper.writeValueAsString(statsData);
+            stubGetAllDayOfWeekReservationStats(200, expectedResponse);
+
+            // when
+            reservationStatsService.updateAllDayOfWeekReservationStats();
+
+            // then
+            assertThat(dayOfWeekReservationCountRepository.findByPopupId(popup.getId())).isEmpty();
+            assertThat(dayOfWeekReservationCountRepository.findByPopupId(popup2.getId()))
+                    .isPresent();
+        }
+
+        @Test
+        void 예약_서비스_연결_실패시_예외가_발생한다() {
+            // given
+            wireMockServer.stop();
+
+            // when & then
+            CustomException exception =
+                    assertThrows(
+                            CustomException.class,
+                            () -> reservationStatsService.updateAllDayOfWeekReservationStats());
+
+            assertThat(exception.getErrorCode())
+                    .isEqualTo(ReservationStatsErrorCode.RESERVATION_SERVICE_CONNECTION_FAILED);
+
+            wireMockServer.start();
+        }
+
+        @Test
+        void 예약_서비스_오류시_예외가_발생한다() {
+            // given
+            wireMockServer.stubFor(
+                    get(urlPathEqualTo("/internal/day-of-week-count"))
+                            .willReturn(aResponse().withStatus(500)));
+
+            // when & then
+            CustomException exception =
+                    assertThrows(
+                            CustomException.class,
+                            () -> reservationStatsService.updateAllDayOfWeekReservationStats());
+
+            assertThat(exception.getErrorCode())
+                    .isEqualTo(ReservationStatsErrorCode.RESERVATION_SERVICE_ERROR);
         }
     }
 
     private void stubFindDailyMemberReservationCount(Long popupId, int status, String body) {
         MappingBuilder mappingBuilder =
                 get(urlPathEqualTo("/internal/" + popupId + "/daily-count"));
+
+        wireMockServer.stubFor(
+                mappingBuilder.willReturn(
+                        aResponse()
+                                .withStatus(status)
+                                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                .withBody(body)));
+    }
+
+    private void stubGetAllDayOfWeekReservationStats(int status, String body) {
+        MappingBuilder mappingBuilder = get(urlPathEqualTo("/internal/day-of-week-count"));
 
         wireMockServer.stubFor(
                 mappingBuilder.willReturn(


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-321]

---
## 📌 작업 내용 및 특이사항

- 미구현 되어있던 reservation-service의 예약 테이블을 조회하여 요일별 예약자 수 제공 기능을 구현했습니다.
- 해당 기능은 스케줄러를 통해 매일 자정에 한 번 집계테이블을 업데이트합니다.
- 실패 시 스케줄러 재시도 로직을 추가하여 총 2번, 10분 뒤에 재시도하도록 설정했습니다.
- 스케줄러를 FeignClient를 통해 reservation-serviec으로 조회 요청을 보내며 팝업 ID별로 분리된 Map<Long, Response> 타입의 데이터를 반환합니다.
- 대시보드 진입시 데이터 조회를 위해 호출되는 external API는 기존에 구현된 메서드를 그대로 사용합니다.
- 예외 상황은 총 2가지로 reservation-service의 응답이 없어 feign 요청에 실패하는 경우와 reservation-service의 DB에서 에러가 발생하여 feignClient가 500 에러를 반환하는 경우입니다.

---
## 📚 참고사항

- 스케줄러 재시도 로직에서 동기 처리 부분인
```java
Thread.sleep(600000); // 10분 동안 현재 스레드 블록
executeRetry(1);
```

- 위의 코드를 다음과 같이 비동기적으로 처리하게 구현했습니다.
```java
private void scheduleRetry() {
        // 10분 후 첫 번째 재시도
        CompletableFuture.delayedExecutor(10, TimeUnit.MINUTES).execute(() -> executeRetry(1));
    }
```
```java
if (attemptNumber < 2) {
                // 10분 후 마지막
                CompletableFuture.delayedExecutor(10, TimeUnit.MINUTES)
                        .execute(() -> executeRetry(attemptNumber + 1));
            }
```


[LCR-321]: https://lgcns-retail.atlassian.net/browse/LCR-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ