### PR TITLE
fix: Kafka Consumer 이벤트 핸들러 호출 누락 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/notification/event/handler/NotificationEventHandler.java
+++ b/src/main/java/com/lgcns/domain/notification/event/handler/NotificationEventHandler.java
@@ -4,10 +4,9 @@ import com.lgcns.domain.notification.event.dto.NotificationEvent;
 import com.lgcns.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @RequiredArgsConstructor
 @Component
@@ -17,7 +16,7 @@ public class NotificationEventHandler {
     private final NotificationService notificationService;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleNotificationEvent(NotificationEvent event) {
         notificationService.sendLowStockMessage(event.popup(), event.item());
     }

--- a/src/main/java/com/lgcns/domain/orderItem/event/handler/OrderItemEventHandler.java
+++ b/src/main/java/com/lgcns/domain/orderItem/event/handler/OrderItemEventHandler.java
@@ -4,10 +4,9 @@ import com.lgcns.domain.orderItem.event.dto.OrderItemEvent;
 import com.lgcns.domain.orderItem.service.OrderItemService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @RequiredArgsConstructor
 @Component
@@ -17,7 +16,7 @@ public class OrderItemEventHandler {
     private final OrderItemService orderItemService;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleOrderItemCreatedEvent(OrderItemEvent event) {
         orderItemService.createOrderItem(event.itemId());
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-353]

---
## 📌 작업 내용 및 특이사항

- Kafka Consumer에서 발생시키는 이벤트(NotificationEvent, OrderItemEvent)에 대해 기존 `@TransactionalEventListener`에서 `@EventListener`로 전환했습니다.
- Consumer 실행 컨텍스트에 트랜잭션이 없어 이벤트 핸들러가 호출되지 않는 문제가 발생하여 이를 수정했습니다.
- Kafka 소비 → 재고 감소 → 발주가 필요한 경우 이벤트 발행 → 웹소켓 알림 및 발주 요청 흐름이 정상 작동하도록 수정했습니다.

[LCR-353]: https://lgcns-retail.atlassian.net/browse/LCR-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ