### PR TITLE
fix: 발주 API 공통응답 적용, Swagger 번호 수정 및 재고 수량 증가 로직 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/auth/externalApi/AuthController.java
+++ b/src/main/java/com/lgcns/domain/auth/externalApi/AuthController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-@Tag(name = "1-1. 인증 API", description = "인증 관련 API입니다.")
+@Tag(name = "01-1. 인증 API", description = "인증 관련 API입니다.")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/lgcns/domain/congestionStats/externalApi/CongestionStatsController.java
+++ b/src/main/java/com/lgcns/domain/congestionStats/externalApi/CongestionStatsController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/popups/{popupId}/dashboard/congestion")
-@Tag(name = "14. 혼잡도 분석 API", description = "혼잡도 분석 관련 API 입니다.")
+@Tag(name = "09. 혼잡도 분석 API", description = "혼잡도 분석 관련 API 입니다.")
 public class CongestionStatsController {
 
     private final CongestionStatsService congestionStatsService;

--- a/src/main/java/com/lgcns/domain/conversionStats/externalApi/ConversionStatsController.java
+++ b/src/main/java/com/lgcns/domain/conversionStats/externalApi/ConversionStatsController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/popups/{popupId}/dashboard")
 @RequiredArgsConstructor
-@Tag(name = "12. 구매전환율 분석 API", description = "구매전환율 분석 관련 API 입니다.")
+@Tag(name = "10. 구매전환율 분석 API", description = "구매전환율 분석 관련 API 입니다.")
 public class ConversionStatsController {
 
     private final ConversionStatsService conversionStatsService;

--- a/src/main/java/com/lgcns/domain/entrance/externalApi/EntranceController.java
+++ b/src/main/java/com/lgcns/domain/entrance/externalApi/EntranceController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/popups/{popupId}/dashboard/entrants")
 @RequiredArgsConstructor
-@Tag(name = "6-1. 입장 API", description = "입장 관련 API 입니다.")
+@Tag(name = "06. 입장 API", description = "입장 관련 API 입니다.")
 public class EntranceController {
 
     private final EntranceService entranceService;

--- a/src/main/java/com/lgcns/domain/image/externalApi/ImageController.java
+++ b/src/main/java/com/lgcns/domain/image/externalApi/ImageController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/images")
 @RequiredArgsConstructor
-@Tag(name = "2. 이미지 API", description = "이미지 관련 API입니다.")
+@Tag(name = "02. 이미지 API", description = "이미지 관련 API입니다.")
 public class ImageController {
 
     private final ImageService imageService;

--- a/src/main/java/com/lgcns/domain/item/domain/Item.java
+++ b/src/main/java/com/lgcns/domain/item/domain/Item.java
@@ -126,7 +126,7 @@ public class Item extends BaseTimeEntity {
         if (stock < 0) {
             throw new CustomException(ItemErrorCode.INVALID_RESTOCK);
         }
-        this.stock = stock;
+        this.stock += stock;
         this.lastRestockDateTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
@@ -22,7 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/popups/{popupId}")
 @RequiredArgsConstructor
-@Tag(name = "4-1. 상품 API", description = "상품 관련 API 입니다.")
+@Tag(name = "04-1. 상품 API", description = "상품 관련 API 입니다.")
 public class ItemController {
 
     private final ItemService itemService;

--- a/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
+++ b/src/main/java/com/lgcns/domain/item/internalApi/ItemInternalController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/internal/popups/{popupId}/items")
 @RequiredArgsConstructor
-@Tag(name = "4-2. 상품 Internal API", description = "상품 관련 Internal API 입니다.")
+@Tag(name = "04-2. 상품 Internal API", description = "상품 관련 Internal API 입니다.")
 public class ItemInternalController {
 
     private final ItemService itemService;

--- a/src/main/java/com/lgcns/domain/manager/externalApi/ManagerController.java
+++ b/src/main/java/com/lgcns/domain/manager/externalApi/ManagerController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/managers")
 @RequiredArgsConstructor
-@Tag(name = "1-2. 운영자 API", description = "운영자 관련 API입니다.")
+@Tag(name = "01-2. 운영자 API", description = "운영자 관련 API입니다.")
 public class ManagerController {
 
     private final ManagerService managerService;

--- a/src/main/java/com/lgcns/domain/notification/externalApi/NotificationController.java
+++ b/src/main/java/com/lgcns/domain/notification/externalApi/NotificationController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/popups/{popupId}/notifications")
 @RequiredArgsConstructor
-@Tag(name = "11. 알림 API", description = "알림 관련 API입니다.")
+@Tag(name = "07. 알림 API", description = "알림 관련 API입니다.")
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/src/main/java/com/lgcns/domain/orderItem/externalApi/OrderItemController.java
+++ b/src/main/java/com/lgcns/domain/orderItem/externalApi/OrderItemController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/order-items")
 @RequiredArgsConstructor
-@Tag(name = "13. 발주 API", description = "발주 관련 External API 입니다.")
+@Tag(name = "08. 발주 API", description = "발주 관련 External API 입니다.")
 public class OrderItemController {
 
     private final OrderItemService orderItemService;

--- a/src/main/java/com/lgcns/domain/paymentStats/externalApi/PaymentStatsController.java
+++ b/src/main/java/com/lgcns/domain/paymentStats/externalApi/PaymentStatsController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/popups/{popupId}/dashboard")
 @RequiredArgsConstructor
-@Tag(name = "5. 1인 평균 구매액 분석 API", description = "1인 평균 구매액 분석 관련 API 입니다.")
+@Tag(name = "14. 1인 평균 구매액 분석 API", description = "1인 평균 구매액 분석 관련 API 입니다.")
 public class PaymentStatsController {
 
     private final PaymentStatsService paymentStatsService;

--- a/src/main/java/com/lgcns/domain/popup/externalApi/PopupController.java
+++ b/src/main/java/com/lgcns/domain/popup/externalApi/PopupController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/popups")
 @RequiredArgsConstructor
-@Tag(name = "3-1. 팝업 API", description = "팝업 관련 API 입니다.")
+@Tag(name = "03-1. 팝업 API", description = "팝업 관련 API 입니다.")
 public class PopupController {
 
     private final PopupService popupService;

--- a/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
+++ b/src/main/java/com/lgcns/domain/popup/internalApi/PopupInternalController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/internal")
 @RequiredArgsConstructor
-@Tag(name = "3-2. 팝업 Internal API", description = "팝업 관련 Internal API 입니다.")
+@Tag(name = "03-2. 팝업 Internal API", description = "팝업 관련 Internal API 입니다.")
 public class PopupInternalController {
 
     private final PopupService popupService;

--- a/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
+++ b/src/main/java/com/lgcns/domain/reservation/internalApi/ReservationInternalController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("internal/reservations")
 @RequiredArgsConstructor
-@Tag(name = "15. 예약 Internal API", description = "예약 관련 Internal API입니다.")
+@Tag(name = "05. 예약 Internal API", description = "예약 관련 Internal API입니다.")
 public class ReservationInternalController {
 
     private final ReservationService reservationService;

--- a/src/main/java/com/lgcns/domain/reservationStats/externalApi/ReservationStatsController.java
+++ b/src/main/java/com/lgcns/domain/reservationStats/externalApi/ReservationStatsController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/popups/{popupId}/dashboard/reservations")
 @RequiredArgsConstructor
-@Tag(name = "9. 예약 분석 API", description = "예약 분석 관련 API 입니다.")
+@Tag(name = "11. 예약 분석 API", description = "예약 분석 관련 API 입니다.")
 public class ReservationStatsController {
 
     private final ReservationStatsService reservationStatsService;

--- a/src/main/java/com/lgcns/domain/survey/externalApi/SurveyController.java
+++ b/src/main/java/com/lgcns/domain/survey/externalApi/SurveyController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/popups/{popupId}/dashboard/surveys")
 @RequiredArgsConstructor
-@Tag(name = "8. 설문지 분석 API", description = "설문지 분석 관련 API 입니다.")
+@Tag(name = "13. 설문지 분석 API", description = "설문지 분석 관련 API 입니다.")
 public class SurveyController {
 
     private final SurveyService surveyService;

--- a/src/main/java/com/lgcns/domain/visitorStats/externalApi/VisitorStatsController.java
+++ b/src/main/java/com/lgcns/domain/visitorStats/externalApi/VisitorStatsController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/popups/{popupId}/dashboard")
 @RequiredArgsConstructor
-@Tag(name = "7. 방문자 분석 API", description = "대시보드에서 방문자 분석을 위한 API입니다.")
+@Tag(name = "10. 방문자 분석 API", description = "대시보드에서 방문자 분석을 위한 API입니다.")
 public class VisitorStatsController {
 
     private final VisitorStatsService visitorStatsService;

--- a/src/main/java/com/lgcns/global/common/response/GlobalResponseAdvice.java
+++ b/src/main/java/com/lgcns/global/common/response/GlobalResponseAdvice.java
@@ -26,7 +26,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
             "com.lgcns.domain.reservation.externalApi",
             "com.lgcns.domain.reservationStats.externalApi",
             "com.lgcns.domain.survey.externalApi",
-            "com.lgcns.domain.visitorStats.externalApi"
+            "com.lgcns.domain.visitorStats.externalApi",
+            "com.lgcns.domain.orderItem.externalApi"
         })
 public class GlobalResponseAdvice implements ResponseBodyAdvice {
 

--- a/src/test/java/com/lgcns/domain/orderItem/service/OrderItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/orderItem/service/OrderItemServiceTest.java
@@ -189,6 +189,7 @@ public class OrderItemServiceTest extends IntegrationTest {
             assertThat(updatedOrderItem.getRealCount()).isEqualTo(10);
             assertThat(updatedOrderItem.getStatus()).isEqualTo(OrderItemStatus.COMPLETED);
             assertThat(updatedOrderItem.getItem().getIsAlarmed()).isFalse();
+            assertThat(updatedOrderItem.getItem().getStock()).isEqualTo(15);
         }
 
         @Test


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-354]

---
## 📌 작업 내용 및 특이사항

- 발주 API에 GlobalResponseAdvice 적용 누락된 부분을 수정했습니다.
- Swagger 태그 넘버링을 수정하여 오름차순으로 정렬되도록 변경했습니다 (ex. 1 → 01).
- 통계 관련 API들은 가독성을 위해 뒤쪽으로 위치를 조정했습니다.
- 발주 시 재고 수량 증가 로직이 잘못 적용되어 있던 부분을 수정했습니다. (기존: stock을 덮어쓰던 로직 → 수량만큼 증가하도록 변경)

[LCR-354]: https://lgcns-retail.atlassian.net/browse/LCR-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ