### PR TITLE
refactor: WebSocket 이벤트 핸들러 로깅 정리 (구독 이벤트만 유지)

### DIFF
--- a/src/main/java/com/lgcns/global/websocket/WebSocketEventHandler.java
+++ b/src/main/java/com/lgcns/global/websocket/WebSocketEventHandler.java
@@ -2,55 +2,13 @@ package com.lgcns.global.websocket;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.messaging.*;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 @Slf4j
 @Component
 public class WebSocketEventHandler {
-
-    @EventListener
-    public void handleWebSocketSessionConnect(SessionConnectEvent event) {
-        logConnectEvent(event);
-    }
-
-    private void logConnectEvent(SessionConnectEvent event) {
-        StompHeaderAccessor accessor =
-                MessageHeaderAccessor.getAccessor(event.getMessage(), StompHeaderAccessor.class);
-
-        Authentication authentication = (Authentication) accessor.getUser();
-        if (authentication == null) {
-            log.warn("WebSocket connected without authentication");
-            return;
-        }
-
-        String username = authentication.getName();
-        String userRole =
-                authentication.getAuthorities().stream()
-                        .findFirst()
-                        .map(GrantedAuthority::getAuthority)
-                        .orElseThrow(() -> new IllegalArgumentException("User role is not exist."));
-
-        log.info(
-                "WebSocket {}: username={}, userRole={}",
-                event.getClass().getSimpleName(),
-                username,
-                userRole);
-    }
-
-    @EventListener(SessionConnectedEvent.class)
-    public void handleWebSocketSessionConnected() {
-        log.info("WebSocket Connected");
-    }
-
-    @EventListener
-    public void handleWebSocketSessionDisconnected(SessionDisconnectEvent event) {
-        log.info("WebSocket Disconnected");
-    }
 
     @EventListener(SessionSubscribeEvent.class)
     public void handleWebSocketSessionSubscribe() {


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-361]

---
## 📌 작업 내용 및 특이사항

- WebSocket 연결 및 해제 이벤트에서 불필요한 로깅을 제거했습니다.
- 구독 및 구독 해제(SessionSubscribeEvent, SessionUnsubscribeEvent) 이벤트만 로깅하도록 정리했습니다.
- 인증 정보 조회 및 연결 관련 예외 발생 가능성을 줄이고, 운영 시 노이즈 로그를 최소화했습니다.

[LCR-361]: https://lgcns-retail.atlassian.net/browse/LCR-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ