### PR TITLE
fix: 엑셀 파일 상품 등록 기능 수정

### DIFF
--- a/src/main/java/com/lgcns/domain/item/dto/response/ItemBulkCreateResponse.java
+++ b/src/main/java/com/lgcns/domain/item/dto/response/ItemBulkCreateResponse.java
@@ -1,0 +1,18 @@
+package com.lgcns.domain.item.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 일괄 등록 응답 DTO")
+public record ItemBulkCreateResponse(
+        @Schema(description = "처리된 총 행 수", example = "20") int totalRows,
+        @Schema(description = "성공한 상품 수", example = "20") int successCount,
+        @Schema(description = "처리 결과 메시지", example = "20개 상품이 성공적으로 등록되었습니다.") String message) {
+    public static ItemBulkCreateResponse of(int totalRows, int successCount, String message) {
+        return new ItemBulkCreateResponse(totalRows, successCount, message);
+    }
+
+    public static ItemBulkCreateResponse success(int successCount) {
+        return new ItemBulkCreateResponse(
+                successCount, successCount, String.format("%d개 상품이 성공적으로 등록되었습니다.", successCount));
+    }
+}

--- a/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
+++ b/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
@@ -14,7 +14,10 @@ public enum ItemErrorCode implements ErrorCode {
 
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "요청한 수량이 현재 재고보다 많습니다."),
     INVALID_RESTOCK(HttpStatus.BAD_REQUEST, "재고 수량은 0 이상이어야 합니다."),
-    ;
+
+    EXCEL_FILE_INVALID(HttpStatus.BAD_REQUEST, "엑셀 파일이 올바르지 않습니다."),
+    EXCEL_DATA_INVALID(HttpStatus.BAD_REQUEST, "엑셀 데이터가 올바르지 않습니다."),
+    EXCEL_PROCESSING_FAILED(HttpStatus.BAD_REQUEST, "엑셀 파일 처리에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
+++ b/src/main/java/com/lgcns/domain/item/exception/ItemErrorCode.java
@@ -15,6 +15,11 @@ public enum ItemErrorCode implements ErrorCode {
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "요청한 수량이 현재 재고보다 많습니다."),
     INVALID_RESTOCK(HttpStatus.BAD_REQUEST, "재고 수량은 0 이상이어야 합니다."),
 
+    FILE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "요청된 파일이 없습니다."),
+    FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "업로드 파일 크기가 제한을 초과했습니다. (최대 10MB)"),
+    INVALID_FILE_TYPE(
+            HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다. Excel 파일(.xlsx, .xls)만 업로드 가능합니다."),
+
     EXCEL_FILE_INVALID(HttpStatus.BAD_REQUEST, "엑셀 파일이 올바르지 않습니다."),
     EXCEL_DATA_INVALID(HttpStatus.BAD_REQUEST, "엑셀 데이터가 올바르지 않습니다."),
     EXCEL_PROCESSING_FAILED(HttpStatus.BAD_REQUEST, "엑셀 파일 처리에 실패했습니다.");

--- a/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
@@ -2,6 +2,7 @@ package com.lgcns.domain.item.externalApi;
 
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
+import com.lgcns.domain.item.dto.response.ItemBulkCreateResponse;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import com.lgcns.domain.item.dto.response.ItemTrendingResponse;
@@ -9,11 +10,9 @@ import com.lgcns.domain.item.service.ItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,12 +35,12 @@ public class ItemController {
     }
 
     @PostMapping("/items/excel")
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "excel 상품 파일 등록", description = "excel 파일을 업로드하여 상품 리스트를 등록합니다.")
-    public ResponseEntity<Void> itemCreateByExcel(
-            @PathVariable Long popupId, @RequestPart(value = "itemFile") MultipartFile itemFile)
-            throws IOException, InvalidFormatException {
-        itemService.createItemByExcel(popupId, itemFile);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+    public ItemBulkCreateResponse itemCreateByExcel(
+            @PathVariable Long popupId, @RequestParam("itemFile") MultipartFile itemFile) {
+
+        return itemService.createItemByExcel(popupId, itemFile);
     }
 
     @GetMapping("/items")

--- a/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
@@ -38,7 +38,8 @@ public class ItemController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "excel 상품 파일 등록", description = "excel 파일을 업로드하여 상품 리스트를 등록합니다.")
     public ItemBulkCreateResponse itemCreateByExcel(
-            @PathVariable Long popupId, @RequestParam(value = "itemFile") MultipartFile itemFile) {
+            @PathVariable Long popupId,
+            @RequestParam(value = "itemFile", required = false) MultipartFile itemFile) {
 
         return itemService.createItemByExcel(popupId, itemFile);
     }

--- a/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
+++ b/src/main/java/com/lgcns/domain/item/externalApi/ItemController.java
@@ -38,7 +38,7 @@ public class ItemController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "excel 상품 파일 등록", description = "excel 파일을 업로드하여 상품 리스트를 등록합니다.")
     public ItemBulkCreateResponse itemCreateByExcel(
-            @PathVariable Long popupId, @RequestParam("itemFile") MultipartFile itemFile) {
+            @PathVariable Long popupId, @RequestParam(value = "itemFile") MultipartFile itemFile) {
 
         return itemService.createItemByExcel(popupId, itemFile);
     }

--- a/src/main/java/com/lgcns/domain/item/service/ItemService.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemService.java
@@ -6,22 +6,20 @@ import com.lgcns.domain.item.client.dto.response.ItemInfoResponse;
 import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
+import com.lgcns.domain.item.dto.response.ItemBulkCreateResponse;
 import com.lgcns.domain.item.dto.response.ItemDetailResponse;
 import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
 import com.lgcns.domain.item.dto.response.ItemTrendingResponse;
 import com.lgcns.global.common.response.SliceResponse;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ItemService {
 
     void createItem(Long popupId, ItemCreateRequest request);
 
-    void createItemByExcel(Long popupId, MultipartFile itemFile)
-            throws InvalidFormatException, IOException;
+    ItemBulkCreateResponse createItemByExcel(Long popupId, MultipartFile itemFile);
 
     Map<String, List<ItemPreviewResponse>> findAllItems(Long popupId);
 

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -286,8 +286,6 @@ public class ItemServiceImpl implements ItemService {
                 throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
             }
 
-        } catch (CustomException e) {
-            throw e;
         } catch (Exception e) {
             throw new CustomException(ItemErrorCode.EXCEL_PROCESSING_FAILED);
         }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -285,7 +285,8 @@ public class ItemServiceImpl implements ItemService {
             } else {
                 throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
             }
-
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
             throw new CustomException(ItemErrorCode.EXCEL_PROCESSING_FAILED);
         }

--- a/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/lgcns/domain/item/service/ItemServiceImpl.java
@@ -7,12 +7,10 @@ import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.dto.ItemScore;
 import com.lgcns.domain.item.dto.request.ItemCreateRequest;
 import com.lgcns.domain.item.dto.request.ItemMinStockUpdateRequest;
-import com.lgcns.domain.item.dto.response.ItemDetailResponse;
-import com.lgcns.domain.item.dto.response.ItemLocationResponse;
-import com.lgcns.domain.item.dto.response.ItemPreviewResponse;
-import com.lgcns.domain.item.dto.response.ItemTrendingResponse;
+import com.lgcns.domain.item.dto.response.*;
 import com.lgcns.domain.item.exception.ItemErrorCode;
 import com.lgcns.domain.item.repository.ItemRepository;
+import com.lgcns.domain.item.util.ItemExcelUtil;
 import com.lgcns.domain.manager.domain.Manager;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.domain.popup.exception.PopupErrorCode;
@@ -23,7 +21,6 @@ import com.lgcns.global.util.ManagerUtil;
 import com.lgcns.infra.dynamodb.itemAnalysis.PopupEventDynamoDbClient;
 import com.lgcns.infra.dynamodb.itemAnalysis.PopupEventResponse;
 import com.querydsl.core.Tuple;
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -32,8 +29,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
-import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -41,6 +37,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.View;
 
 @Service
 @RequiredArgsConstructor
@@ -54,6 +51,7 @@ public class ItemServiceImpl implements ItemService {
     private final PopupEventDynamoDbClient dynamoDbClient;
 
     private final int DASHBOARD_HOT_ITEM_SIZE = 3;
+    private final View error;
 
     @Override
     public void createItem(Long popupId, ItemCreateRequest request) {
@@ -76,45 +74,21 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
-    public void createItemByExcel(Long popupId, MultipartFile itemFile)
-            throws InvalidFormatException, IOException {
+    public ItemBulkCreateResponse createItemByExcel(Long popupId, MultipartFile itemFile) {
+
+        ItemExcelUtil.validateExcelFile(itemFile);
+
         final Manager currentManager = managerUtil.getCurrentManager();
         final Popup popup = findPopupById(popupId);
-
         validatePopupOwnership(currentManager, popup);
 
-        // try-with-resources
-        try (InputStream inputStream = itemFile.getInputStream();
-                OPCPackage opcPackage = OPCPackage.open(inputStream);
-                XSSFWorkbook workbook = new XSSFWorkbook(opcPackage)) {
+        Sheet sheet = openExcelSheet(itemFile);
+        ItemExcelUtil.validateSheet(sheet);
 
-            // 첫 번째 sheet 읽기
-            String sheetName = workbook.getSheetName(0);
-            Sheet sheet = workbook.getSheet(sheetName);
+        List<Item> validItems = processExcelData(popup, sheet);
+        saveItems(validItems, popupId);
 
-            int rows = sheet.getPhysicalNumberOfRows();
-            List<Item> items = new ArrayList<>();
-
-            // row 0은 header
-            for (int rowIndex = 0; rowIndex <= rows; rowIndex++) {
-                Row row = sheet.getRow(rowIndex);
-
-                if (rowIndex == 0 || row == null) {
-                    continue;
-                }
-
-                String name = row.getCell(0).getStringCellValue();
-                String imageUrl = row.getCell(1).getStringCellValue();
-                int price = (int) row.getCell(2).getNumericCellValue();
-                int stock = (int) row.getCell(3).getNumericCellValue();
-                int minStock = (int) row.getCell(4).getNumericCellValue();
-                String location = row.getCell(5).getStringCellValue();
-
-                items.add(Item.createItem(popup, name, imageUrl, price, stock, minStock, location));
-            }
-
-            itemRepository.saveAll(items);
-        }
+        return ItemBulkCreateResponse.success(validItems.size());
     }
 
     @Override
@@ -287,6 +261,94 @@ public class ItemServiceImpl implements ItemService {
 
         if (!validItems.isEmpty()) {
             itemRepository.bulkUpdate(validItems);
+        }
+    }
+
+    private Sheet openExcelSheet(MultipartFile itemFile) {
+        try {
+            // 파일 확장자 확인
+            String originalFilename = itemFile.getOriginalFilename();
+            if (originalFilename == null) {
+                throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+            }
+
+            InputStream inputStream = itemFile.getInputStream();
+
+            if (originalFilename.toLowerCase().endsWith(".xlsx")) {
+                // .xlsx 파일 처리
+                XSSFWorkbook workbook = new XSSFWorkbook(inputStream);
+                return workbook.getSheetAt(0);
+            } else if (originalFilename.toLowerCase().endsWith(".xls")) {
+                // .xls 파일 처리
+                HSSFWorkbook workbook = new HSSFWorkbook(inputStream);
+                return workbook.getSheetAt(0);
+            } else {
+                throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+            }
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(ItemErrorCode.EXCEL_PROCESSING_FAILED);
+        }
+    }
+
+    private List<Item> processExcelData(Popup popup, Sheet sheet) {
+        int totalRows = sheet.getPhysicalNumberOfRows();
+        List<Item> validItems = new ArrayList<>();
+        List<String> errorMessages = new ArrayList<>();
+
+        int processedRows = 0;
+
+        for (int rowIdx = 1; rowIdx < totalRows; rowIdx++) {
+            Row row = sheet.getRow(rowIdx);
+
+            if (ItemExcelUtil.isEmptyRow(row)) {
+                continue;
+            }
+
+            processedRows++;
+
+            try {
+                Item item = ItemExcelUtil.parseRowToItem(popup, row, rowIdx);
+                validItems.add(item);
+            } catch (Exception e) {
+                String errorMessage = String.format("Row %d: %s", rowIdx + 1, e.getMessage());
+                errorMessages.add(errorMessage);
+            }
+        }
+
+        validateProcessingResult(processedRows, errorMessages);
+
+        return validItems;
+    }
+
+    private void validateProcessingResult(int processedRows, List<String> errorMessages) {
+        if (processedRows == 0) {
+            throw new CustomException(ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        if (!errorMessages.isEmpty()) {
+            String combinedMessage = String.join("; ", errorMessages);
+
+            throw new CustomException(ItemErrorCode.EXCEL_DATA_INVALID) {
+                @Override
+                public String getMessage() {
+                    return super.getMessage() + " 상세: " + combinedMessage;
+                }
+            };
+        }
+    }
+
+    private void saveItems(List<Item> validItems, Long popupId) {
+        if (validItems.isEmpty()) {
+            throw new CustomException(ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        try {
+            itemRepository.saveAll(validItems);
+        } catch (Exception e) {
+            throw new CustomException(ItemErrorCode.EXCEL_PROCESSING_FAILED);
         }
     }
 

--- a/src/main/java/com/lgcns/domain/item/util/ItemExcelUtil.java
+++ b/src/main/java/com/lgcns/domain/item/util/ItemExcelUtil.java
@@ -44,8 +44,6 @@ public class ItemExcelUtil {
 
             return Item.createItem(popup, name, imageUrl, price, stock, minStock, location);
 
-        } catch (CustomException e) {
-            throw e;
         } catch (Exception e) {
             throw new RuntimeException(
                     String.format("Row %d 처리 중 오류: %s", rowIdx + 1, e.getMessage()));

--- a/src/main/java/com/lgcns/domain/item/util/ItemExcelUtil.java
+++ b/src/main/java/com/lgcns/domain/item/util/ItemExcelUtil.java
@@ -1,0 +1,197 @@
+package com.lgcns.domain.item.util;
+
+import com.lgcns.domain.item.domain.Item;
+import com.lgcns.domain.item.exception.ItemErrorCode;
+import com.lgcns.domain.popup.domain.Popup;
+import com.lgcns.global.error.exception.CustomException;
+import org.apache.poi.ss.usermodel.*;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ItemExcelUtil {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+    // 엑셀 파일 기본 검증
+    public static void validateExcelFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+        }
+
+        String fileName = file.getOriginalFilename();
+        if (fileName == null || (!fileName.endsWith(".xlsx") && !fileName.endsWith(".xls"))) {
+            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+        }
+    }
+
+    // 행 데이터를 Item 엔티티로 변환
+    public static Item parseRowToItem(Popup popup, Row row, int rowIndex) {
+        try {
+            String name = getCellStringValue(row.getCell(0));
+            String imageUrl = getCellStringValue(row.getCell(1));
+            int price = getCellIntValue(row.getCell(2));
+            int stock = getCellIntValue(row.getCell(3));
+            int minStock = getCellIntValue(row.getCell(4));
+            String location = getCellStringValue(row.getCell(5));
+
+            // 데이터 검증
+            validateItemData(name, imageUrl, price, stock, minStock, location);
+
+            return Item.createItem(popup, name, imageUrl, price, stock, minStock, location);
+
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format("Row %d 처리 중 오류: %s", rowIndex + 1, e.getMessage()));
+        }
+    }
+
+    // 문자열 값 읽기
+    public static String getCellStringValue(Cell cell) {
+        if (cell == null) {
+            return "";
+        }
+
+        return switch (cell.getCellType()) {
+            case STRING -> cell.getStringCellValue().trim();
+            case NUMERIC -> {
+                if (DateUtil.isCellDateFormatted(cell)) {
+                    yield cell.getLocalDateTimeCellValue().toString();
+                } else {
+                    double numericValue = cell.getNumericCellValue();
+                    // 소수점 제거
+                    if (numericValue == Math.floor(numericValue)) {
+                        yield String.valueOf((long) numericValue);
+                    } else {
+                        yield String.valueOf(numericValue);
+                    }
+                }
+            }
+            case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+            case FORMULA -> {
+                try {
+                    FormulaEvaluator evaluator =
+                            cell.getSheet()
+                                    .getWorkbook()
+                                    .getCreationHelper()
+                                    .createFormulaEvaluator();
+                    CellValue cellValue = evaluator.evaluate(cell);
+                    yield switch (cellValue.getCellType()) {
+                        case STRING -> cellValue.getStringValue().trim();
+                        case NUMERIC -> String.valueOf((long) cellValue.getNumberValue());
+                        case BOOLEAN -> String.valueOf(cellValue.getBooleanValue());
+                        default -> "";
+                    };
+                } catch (Exception e) {
+                    yield "";
+                }
+            }
+            case BLANK, _NONE -> "";
+            default -> "";
+        };
+    }
+
+    // 정수 값 읽기
+    public static int getCellIntValue(Cell cell) {
+        if (cell == null) {
+            throw new IllegalArgumentException("필수 값이 없습니다");
+        }
+
+        return switch (cell.getCellType()) {
+            case NUMERIC -> {
+                double value = cell.getNumericCellValue();
+                if (value < 0) {
+                    throw new IllegalArgumentException("0 이상의 값이어야 합니다");
+                }
+                if (value > Integer.MAX_VALUE) {
+                    throw new IllegalArgumentException("값이 너무 큽니다");
+                }
+                yield (int) value;
+            }
+            case STRING -> {
+                String stringValue = cell.getStringCellValue().trim();
+                if (stringValue.isEmpty()) {
+                    throw new IllegalArgumentException("필수 값이 없습니다");
+                }
+                try {
+                    int value = Integer.parseInt(stringValue);
+                    if (value < 0) {
+                        throw new IllegalArgumentException("0 이상의 값이어야 합니다");
+                    }
+                    yield value;
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("숫자 형식이 아닙니다: " + stringValue);
+                }
+            }
+            case FORMULA -> {
+                try {
+                    FormulaEvaluator evaluator =
+                            cell.getSheet()
+                                    .getWorkbook()
+                                    .getCreationHelper()
+                                    .createFormulaEvaluator();
+                    CellValue cellValue = evaluator.evaluate(cell);
+                    if (cellValue.getCellType() == CellType.NUMERIC) {
+                        double value = cellValue.getNumberValue();
+                        if (value < 0) {
+                            throw new IllegalArgumentException("0 이상의 값이어야 합니다");
+                        }
+                        yield (int) value;
+                    } else {
+                        throw new IllegalArgumentException("수식 결과가 숫자가 아닙니다");
+                    }
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("수식 계산에 실패했습니다");
+                }
+            }
+            default -> throw new IllegalArgumentException("지원하지 않는 셀 형식입니다: " + cell.getCellType());
+        };
+    }
+
+    // 빈 행 체크
+    public static boolean isEmptyRow(Row row) {
+        if (row == null) {
+            return true;
+        }
+
+        // 6개 컬럼 확인 (상품명, 이미지URL, 가격, 재고, 최소재고, 위치)
+        for (int i = 0; i < 6; i++) {
+            Cell cell = row.getCell(i);
+            String value = getCellStringValue(cell);
+            if (!value.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // 상품 데이터 검증
+    public static void validateItemData(
+            String name, String imageUrl, int price, int stock, int minStock, String location) {
+        if (name.trim().isEmpty()) {
+            throw new IllegalArgumentException("상품명은 필수입니다");
+        }
+
+        if (imageUrl.trim().isEmpty()) {
+            throw new IllegalArgumentException("이미지URL은 필수입니다");
+        }
+
+        if (location.trim().isEmpty()) {
+            throw new IllegalArgumentException("위치는 필수입니다");
+        }
+
+        if (minStock > stock) {
+            throw new IllegalArgumentException(
+                    String.format("최소재고(%d)는 재고(%d)보다 클 수 없습니다", minStock, stock));
+        }
+    }
+
+    // 엑셀 시트 기본 검증
+    public static void validateSheet(Sheet sheet) {
+        if (sheet.getPhysicalNumberOfRows() <= 1) {
+            throw new IllegalArgumentException("엑셀 파일에 데이터가 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/lgcns/domain/item/util/ItemExcelUtil.java
+++ b/src/main/java/com/lgcns/domain/item/util/ItemExcelUtil.java
@@ -4,6 +4,8 @@ import com.lgcns.domain.item.domain.Item;
 import com.lgcns.domain.item.exception.ItemErrorCode;
 import com.lgcns.domain.popup.domain.Popup;
 import com.lgcns.global.error.exception.CustomException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.poi.ss.usermodel.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,21 +16,21 @@ public class ItemExcelUtil {
     // 엑셀 파일 기본 검증
     public static void validateExcelFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
-            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+            throw new CustomException(ItemErrorCode.FILE_NOT_PROVIDED);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new CustomException(ItemErrorCode.FILE_TOO_LARGE);
         }
 
         String fileName = file.getOriginalFilename();
         if (fileName == null || (!fileName.endsWith(".xlsx") && !fileName.endsWith(".xls"))) {
-            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
-        }
-
-        if (file.getSize() > MAX_FILE_SIZE) {
-            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+            throw new CustomException(ItemErrorCode.INVALID_FILE_TYPE);
         }
     }
 
     // 행 데이터를 Item 엔티티로 변환
-    public static Item parseRowToItem(Popup popup, Row row, int rowIndex) {
+    public static Item parseRowToItem(Popup popup, Row row, int rowIdx) {
         try {
             String name = getCellStringValue(row.getCell(0));
             String imageUrl = getCellStringValue(row.getCell(1));
@@ -38,13 +40,15 @@ public class ItemExcelUtil {
             String location = getCellStringValue(row.getCell(5));
 
             // 데이터 검증
-            validateItemData(name, imageUrl, price, stock, minStock, location);
+            validateItemData(name, imageUrl, price, stock, minStock, location, rowIdx);
 
             return Item.createItem(popup, name, imageUrl, price, stock, minStock, location);
 
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(
-                    String.format("Row %d 처리 중 오류: %s", rowIndex + 1, e.getMessage()));
+                    String.format("Row %d 처리 중 오류: %s", rowIdx + 1, e.getMessage()));
         }
     }
 
@@ -169,29 +173,67 @@ public class ItemExcelUtil {
 
     // 상품 데이터 검증
     public static void validateItemData(
-            String name, String imageUrl, int price, int stock, int minStock, String location) {
-        if (name.trim().isEmpty()) {
-            throw new IllegalArgumentException("상품명은 필수입니다");
+            String name,
+            String imageUrl,
+            int price,
+            int stock,
+            int minStock,
+            String location,
+            int rowIdx) {
+        List<String> errors = new ArrayList<>();
+        if (name == null || name.trim().isEmpty()) {
+            errors.add("상품명은 필수입니다");
         }
 
-        if (imageUrl.trim().isEmpty()) {
-            throw new IllegalArgumentException("이미지URL은 필수입니다");
+        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+            errors.add("이미지 URL은 필수입니다");
         }
 
-        if (location.trim().isEmpty()) {
-            throw new IllegalArgumentException("위치는 필수입니다");
+        if (price < 0) {
+            errors.add("가격은 0 이상이어야 합니다");
+        }
+
+        if (stock < 0) {
+            errors.add("재고는 0 이상이어야 합니다");
+        }
+
+        if (minStock < 0) {
+            errors.add("최소재고는 0 이상이어야 합니다");
         }
 
         if (minStock > stock) {
-            throw new IllegalArgumentException(
-                    String.format("최소재고(%d)는 재고(%d)보다 클 수 없습니다", minStock, stock));
+            errors.add(String.format("최소재고(%d)는 재고(%d)보다 클 수 없습니다", minStock, stock));
+        }
+
+        if (location == null || location.trim().isEmpty()) {
+            errors.add("위치는 필수입니다");
+        }
+
+        if (!errors.isEmpty()) {
+            String errorMessage =
+                    String.format("Row %d: %s", rowIdx + 1, String.join(", ", errors));
+            throw new CustomException(ItemErrorCode.EXCEL_DATA_INVALID) {
+                @Override
+                public String getMessage() {
+                    return errorMessage;
+                }
+            };
         }
     }
 
     // 엑셀 시트 기본 검증
     public static void validateSheet(Sheet sheet) {
+        if (sheet == null) {
+            throw new CustomException(ItemErrorCode.EXCEL_FILE_INVALID);
+        }
+
         if (sheet.getPhysicalNumberOfRows() <= 1) {
-            throw new IllegalArgumentException("엑셀 파일에 데이터가 없습니다");
+            throw new CustomException(ItemErrorCode.EXCEL_DATA_INVALID) {
+                @Override
+                public String getMessage() {
+                    return "엑셀 파일에 데이터가 없습니다. 헤더 외에 최소 1개 이상의 데이터 행이 필요합니다.";
+                }
+            };
         }
     }
 }

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(basePackages = "com.lgcns")
@@ -29,6 +30,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
 
         return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+
+    // MultipartException 처리
+    @ExceptionHandler(MultipartException.class)
+    protected ResponseEntity<GlobalResponse> handleMultipartException(MultipartException e) {
+
+        String message = "파일 업로드 중 오류가 발생했습니다.";
+        String errorClassName = "MULTIPART_SYSTEM_ERROR";
+
+        final ErrorResponse errorResponse = ErrorResponse.of(errorClassName, message);
+        final GlobalResponse response =
+                GlobalResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), errorResponse);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
     /**

--- a/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lgcns/global/error/GlobalExceptionHandler.java
@@ -16,10 +16,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(basePackages = "com.lgcns")
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private final View error;
+
+    public GlobalExceptionHandler(View error) {
+        this.error = error;
+    }
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<GlobalResponse> handleCustomException(CustomException e) {
@@ -35,15 +42,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // MultipartException 처리
     @ExceptionHandler(MultipartException.class)
     protected ResponseEntity<GlobalResponse> handleMultipartException(MultipartException e) {
-
-        String message = "파일 업로드 중 오류가 발생했습니다.";
-        String errorClassName = "MULTIPART_SYSTEM_ERROR";
-
-        final ErrorResponse errorResponse = ErrorResponse.of(errorClassName, message);
+        final ErrorCode errorCode = GlobalErrorCode.MULTIPART_SYSTEM_ERROR;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
         final GlobalResponse response =
-                GlobalResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), errorResponse);
+                GlobalResponse.fail(errorCode.getHttpStatus().value(), errorResponse);
 
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        return ResponseEntity.status(errorCode.getHttpStatus().value()).body(response);
     }
 
     /**

--- a/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
+++ b/src/main/java/com/lgcns/global/error/exception/GlobalErrorCode.java
@@ -10,7 +10,7 @@ public enum GlobalErrorCode implements ErrorCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP method 입니다."),
     METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 값의 타입이 잘못되어 처리할 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
-    ;
+    MULTIPART_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/lgcns/global/logging/filter/HttpLoggingFilter.java
+++ b/src/main/java/com/lgcns/global/logging/filter/HttpLoggingFilter.java
@@ -1,5 +1,7 @@
 package com.lgcns.global.logging.filter;
 
+import static org.springframework.web.multipart.support.MultipartResolutionDelegate.isMultipartRequest;
+
 import com.lgcns.global.logging.dto.HttpRequestLogInfo;
 import com.lgcns.global.logging.dto.HttpResponseLogInfo;
 import com.lgcns.global.logging.filter.wrapper.RequestWrapper;
@@ -26,6 +28,8 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         MDC.put("traceId", UUID.randomUUID().toString());
         if (isAsyncDispatch(request)) {
+            filterChain.doFilter(request, response);
+        } else if (isMultipartRequest(request)) {
             filterChain.doFilter(request, response);
         } else {
             doFilterWrapped(

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,13 @@ spring:
     locations: classpath:db/migration
   kafka:
     bootstrap-servers: localhost:29092
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+      file-size-threshold: 2KB
+      resolve-lazily: false
 
 eureka:
   instance:

--- a/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/lgcns/domain/item/service/ItemServiceTest.java
@@ -108,7 +108,7 @@ class ItemServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 상품_등록 {
+    class 상품_하나를_등록할_때 {
 
         @Test
         void 유효한_입력_값이면_상품_등록에_성공한다() {
@@ -161,20 +161,15 @@ class ItemServiceTest extends IntegrationTest {
     }
 
     @Nested
-    class 엑셀_파일_상품_등록 {
+    class 요청받은_엑셀_파일로_상품을_생성할_때 {
 
         @Test
-        void 유효한_엑셀파일로_상품_등록에_성공한다() throws IOException {
+        void xlsx_파일_업로드에_성공한다() throws IOException {
             // given
-            MultipartFile excelFile = createExcelFile();
+            MultipartFile excelFile = createValidExcelFile();
 
             // when
-            try {
-                itemService.createItemByExcel(popup.getId(), excelFile);
-            } catch (Exception e) {
-                e.printStackTrace();
-                Assertions.fail("엑셀 업로드 실패: " + e.getMessage());
-            }
+            itemService.createItemByExcel(popup.getId(), excelFile);
 
             // then
             List<Item> items = itemRepository.findAll();
@@ -208,22 +203,123 @@ class ItemServiceTest extends IntegrationTest {
         }
 
         @Test
-        void 존재하지_않는_팝업_ID로_엑셀_상품_등록을_시도하면_실패한다() throws IOException {
+        void 파일이_없으면_예외가_발생한다() {
             // given
-            MultipartFile excelFile = createExcelFile();
-            Long nonExistentPopupId = 9999L;
+            MultipartFile nullFile = null;
 
             // when & then
-            assertThatThrownBy(() -> itemService.createItemByExcel(nonExistentPopupId, excelFile))
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), nullFile))
                     .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.FILE_NOT_PROVIDED);
         }
 
-        private MultipartFile createExcelFile() throws IOException {
+        @Test
+        void 파일이_비어있으면_예외가_발생한다() {
+            // given
+            MultipartFile emptyFile =
+                    new MockMultipartFile(
+                            "itemFile",
+                            "empty.xlsx",
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            new byte[0]);
+
+            // when & then
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), emptyFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.FILE_NOT_PROVIDED);
+        }
+
+        @Test
+        void 파일_크기가_10MB를_초과하면_예외가_발생한다() {
+            // given
+            byte[] largeContent = new byte[11 * 1024 * 1024];
+            MultipartFile largeFile =
+                    new MockMultipartFile(
+                            "itemFile",
+                            "large.xlsx",
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            largeContent);
+
+            // when & then
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), largeFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.FILE_TOO_LARGE);
+        }
+
+        @Test
+        void 지원하지_않는_파일_형식이면_예외가_발생한다() {
+            // given
+            MultipartFile txtFile =
+                    new MockMultipartFile(
+                            "itemFile", "test.txt", "text/plain", "test content".getBytes());
+
+            // when & then
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), txtFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.INVALID_FILE_TYPE);
+        }
+
+        @Test
+        void 엑셀에_데이터가_없으면_예외가_발생한다() throws IOException {
+            // given
+            MultipartFile emptyDataFile = createExcelFileWithHeaderOnly();
+
+            // when & then
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), emptyDataFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        @Test
+        void 필수_데이터가_누락되면_예외가_발생한다() throws IOException {
+            // given
+            MultipartFile missingDataFile = createExcelFileWithMissingData();
+
+            // when & then
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), missingDataFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        @Test
+        void 최소재고가_재고보다_크면_예외가_발생한다() throws IOException {
+            // given
+            MultipartFile invalidStockFile = createExcelFileWithInvalidStock();
+
+            // when & then
+            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), invalidStockFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        @Test
+        void 음수_값이_있으면_예외가_발생한다() throws IOException {
+            // given
+            MultipartFile negativeValueFile = createExcelFileWithNegativeValues();
+
+            // when & then
+            assertThatThrownBy(
+                            () -> itemService.createItemByExcel(popup.getId(), negativeValueFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        @Test
+        void 잘못된_데이터_형식이면_예외가_발생한다() throws IOException {
+            // given
+            MultipartFile invalidFormatFile = createExcelFileWithInvalidDataFormat();
+
+            // when & then
+            assertThatThrownBy(
+                            () -> itemService.createItemByExcel(popup.getId(), invalidFormatFile))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ItemErrorCode.EXCEL_DATA_INVALID);
+        }
+
+        private MultipartFile createExcelFileWithHeaderOnly() throws IOException {
             Workbook workbook = new XSSFWorkbook();
             Sheet sheet = workbook.createSheet("Items");
 
-            // 헤더
             Row headerRow = sheet.createRow(0);
             headerRow.createCell(0).setCellValue("상품명");
             headerRow.createCell(1).setCellValue("이미지URL");
@@ -232,7 +328,126 @@ class ItemServiceTest extends IntegrationTest {
             headerRow.createCell(4).setCellValue("최소재고");
             headerRow.createCell(5).setCellValue("위치");
 
-            // 데이터
+            return convertWorkbookToMultipartFile(workbook, "header_only.xlsx");
+        }
+
+        private MultipartFile createExcelFileWithMissingData() throws IOException {
+            Workbook workbook = new XSSFWorkbook();
+            Sheet sheet = workbook.createSheet("Items");
+
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("상품명");
+            headerRow.createCell(1).setCellValue("이미지URL");
+            headerRow.createCell(2).setCellValue("가격");
+            headerRow.createCell(3).setCellValue("재고");
+            headerRow.createCell(4).setCellValue("최소재고");
+            headerRow.createCell(5).setCellValue("위치");
+
+            Row dataRow = sheet.createRow(1);
+            dataRow.createCell(0).setCellValue("");
+            dataRow.createCell(1).setCellValue("https://bucket/item1.jpg");
+            dataRow.createCell(2).setCellValue(5000);
+            dataRow.createCell(3).setCellValue(50);
+            dataRow.createCell(4).setCellValue(5);
+            dataRow.createCell(5).setCellValue("a1");
+
+            return convertWorkbookToMultipartFile(workbook, "missing_data.xlsx");
+        }
+
+        private MultipartFile createExcelFileWithInvalidStock() throws IOException {
+            Workbook workbook = new XSSFWorkbook();
+            Sheet sheet = workbook.createSheet("Items");
+
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("상품명");
+            headerRow.createCell(1).setCellValue("이미지URL");
+            headerRow.createCell(2).setCellValue("가격");
+            headerRow.createCell(3).setCellValue("재고");
+            headerRow.createCell(4).setCellValue("최소재고");
+            headerRow.createCell(5).setCellValue("위치");
+
+            Row dataRow = sheet.createRow(1);
+            dataRow.createCell(0).setCellValue("테스트 상품");
+            dataRow.createCell(1).setCellValue("https://bucket/item1.jpg");
+            dataRow.createCell(2).setCellValue(5000);
+            dataRow.createCell(3).setCellValue(10);
+            dataRow.createCell(4).setCellValue(20);
+            dataRow.createCell(5).setCellValue("a1");
+
+            return convertWorkbookToMultipartFile(workbook, "invalid_stock.xlsx");
+        }
+
+        private MultipartFile createExcelFileWithNegativeValues() throws IOException {
+            Workbook workbook = new XSSFWorkbook();
+            Sheet sheet = workbook.createSheet("Items");
+
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("상품명");
+            headerRow.createCell(1).setCellValue("이미지URL");
+            headerRow.createCell(2).setCellValue("가격");
+            headerRow.createCell(3).setCellValue("재고");
+            headerRow.createCell(4).setCellValue("최소재고");
+            headerRow.createCell(5).setCellValue("위치");
+
+            Row dataRow = sheet.createRow(1);
+            dataRow.createCell(0).setCellValue("테스트 상품");
+            dataRow.createCell(1).setCellValue("https://bucket/item1.jpg");
+            dataRow.createCell(2).setCellValue(-5000);
+            dataRow.createCell(3).setCellValue(50);
+            dataRow.createCell(4).setCellValue(5);
+            dataRow.createCell(5).setCellValue("a1");
+
+            return convertWorkbookToMultipartFile(workbook, "negative_values.xlsx");
+        }
+
+        private MultipartFile createExcelFileWithInvalidDataFormat() throws IOException {
+            Workbook workbook = new XSSFWorkbook();
+            Sheet sheet = workbook.createSheet("Items");
+
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("상품명");
+            headerRow.createCell(1).setCellValue("이미지URL");
+            headerRow.createCell(2).setCellValue("가격");
+            headerRow.createCell(3).setCellValue("재고");
+            headerRow.createCell(4).setCellValue("최소재고");
+            headerRow.createCell(5).setCellValue("위치");
+
+            Row dataRow = sheet.createRow(1);
+            dataRow.createCell(0).setCellValue("테스트 상품");
+            dataRow.createCell(1).setCellValue("https://bucket/item1.jpg");
+            dataRow.createCell(2).setCellValue("invalid_price");
+            dataRow.createCell(3).setCellValue(50);
+            dataRow.createCell(4).setCellValue(5);
+            dataRow.createCell(5).setCellValue("a1");
+
+            return convertWorkbookToMultipartFile(workbook, "invalid_format.xlsx");
+        }
+
+        private MultipartFile convertWorkbookToMultipartFile(Workbook workbook, String filename)
+                throws IOException {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            workbook.write(outputStream);
+            workbook.close();
+
+            return new MockMultipartFile(
+                    "itemFile",
+                    filename,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    new ByteArrayInputStream(outputStream.toByteArray()));
+        }
+
+        private MultipartFile createValidExcelFile() throws IOException {
+            Workbook workbook = new XSSFWorkbook();
+            Sheet sheet = workbook.createSheet("Items");
+
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("상품명");
+            headerRow.createCell(1).setCellValue("이미지URL");
+            headerRow.createCell(2).setCellValue("가격");
+            headerRow.createCell(3).setCellValue("재고");
+            headerRow.createCell(4).setCellValue("최소재고");
+            headerRow.createCell(5).setCellValue("위치");
+
             Row dataRow1 = sheet.createRow(1);
             dataRow1.createCell(0).setCellValue("지수 포토카드");
             dataRow1.createCell(1).setCellValue("https://bucket/item1.jpg");
@@ -257,7 +472,6 @@ class ItemServiceTest extends IntegrationTest {
             dataRow3.createCell(4).setCellValue(10);
             dataRow3.createCell(5).setCellValue("a3");
 
-            // 엑셀파일 -> 바이트 배열
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             workbook.write(outputStream);
             workbook.close();
@@ -267,19 +481,6 @@ class ItemServiceTest extends IntegrationTest {
                     "test_items.xlsx",
                     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                     new ByteArrayInputStream(outputStream.toByteArray()));
-        }
-
-        @Test
-        void 권한이_없는_사용자가_엑셀로_상품을_등록하면_예외가_발생한다() throws IOException {
-            // given
-            setAuthentication(otherManager);
-
-            MultipartFile excelFile = createExcelFile();
-
-            // when & then
-            assertThatThrownBy(() -> itemService.createItemByExcel(popup.getId(), excelFile))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", PopupErrorCode.POPUP_UNAUTHORIZED);
         }
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-362]

---
## 🐛  문제
- 운영자 페이지에서 엑셀 파일을 통한 상품 등록 시, 엑셀 파일이 컨트롤러로 전달되지 않아 상품 등록에 실패했습니다.
- 과도하게 추상회된 에러코드와 빈약한 예외처리 로직으로 인하여 디버깅 시 파악할 수 있는 정보가 제한적이었습니다.

### *원인*
- 이번 이슈의 원인은 LogingFilter에서 InputStream을 선점하여 multi part 타입의 엑셀 파일(byte 배열)을 InputStream으로 받지 못하는 상황이었습니다.

### *해결*
- 로깅 필터에서 request가 multi part 요청인 경우 로그 수집을 배제하도록 분기처리했습니다.
- 추후, 엑셀 파일 등록 api에 대한 로그 수집을 어떻게 할지 논의할 필요가 있습니다. (해당 컨트롤러에서만 log()를 명시하는 방법 등 )

## 📌 작업 내용 및 특이사항
- 커스텀 에러코드를 세분화하여 보다 정확한 의미의 에러 메시지를 반환하도록 했습니다.
- 등록 성공 시, 201 상태코드와 몇 개의 데이터를 성공했는지 파악할 수 있는 ItemBulkCreateResponse를 반환하도록 했습니다.
- 반환 값 변경 (Void -> ItemBulkCreateResponse)애 따라 컨트롤러의 리턴 타입을 변경했습니다.
- 요청으로 파일과 json을 같이 받을 일이 없으므로, 기존의 @RequestPart 에서 @RequestParam으로 변경했습니다.
- 기존의 코드는 파일 유효성 검사 시, Spring 이 파라미터를 검증하기 때문에 컨트롤러 메서드 실행 전에 MultipartException 발생하므로@RequestParam(required = false)으로 설정하여 서비스 로직에서 예외 처리할 수 있도록 했습니다.
- 기존 서비스의 엑셀 파일 검증 및 변환 로직이 복잡하여 ItemExcelUtil 클래스를 구현하여 분리했습니다.
- 엑셀 파일 내부의 데이터 검증 로직을 수행하여 등록 기능이 안전하게 수행되도록 처리했습니다.
---
## 📚 참고사항

- 


[LCR-362]: https://lgcns-retail.atlassian.net/browse/LCR-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ