### PR TITLE
fix: 토큰 재발급 API 인증 없이 접근 가능하도록 Security 설정 수정

### DIFF
--- a/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/lgcns/global/config/security/WebSecurityConfig.java
@@ -60,7 +60,7 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/managers")
                                 .permitAll()
-                                .requestMatchers("/auth/login")
+                                .requestMatchers("/auth/**")
                                 .permitAll()
                                 .requestMatchers("/entrances")
                                 .permitAll()


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-375]

---
## 📌 작업 내용 및 특이사항

- /auth/refresh 엔드포인트에 대해 인증 없이 접근할 수 있도록 permitAll() 설정을 추가했습니다.
- 해당 API는 쿠키 기반의 리프레시 토큰을 사용해 토큰을 재발급하기 때문에 인증이 필요하지 않으며, 기존에는 인증이 필요해 403 오류가 발생할 수 있는 문제가 있었습니다.

[LCR-375]: https://lgcns-retail.atlassian.net/browse/LCR-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ